### PR TITLE
Implement simple signature printing

### DIFF
--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -24,7 +24,7 @@ using Compat
 
 # Exports.
 
-export fields, exports, methodlist, imports
+export fields, exports, methodlist, imports, signatures
 
 
 # Includes.

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -16,7 +16,7 @@ abstract Abbreviation
 Expand the [`Abbreviation`](@ref) `abbr` in the context of the `DocStr` `doc` and write
 the resulting markdown-formatted text to the `IOBuffer` `buf`.
 
-$(:methodlist)
+$(:signatures)
 """
 format(abbr, buf, doc) = error("`format` not implemented for `$typeof(abbr)`.")
 
@@ -244,6 +244,56 @@ function format(::MethodList, buf, doc)
             println(buf, "    ```\n")
         end
         println(buf)
+    end
+    return nothing
+end
+
+
+#
+# `MethodSignatures`
+#
+
+"""
+The singleton type for [`signatures`](@ref) abbreviations.
+
+$(:fields)
+"""
+immutable MethodSignatures <: Abbreviation end
+
+"""
+An [`Abbreviation`](@ref) for including a simplified representation of all the method
+signatures that match the given docstring. See [`printmethod`](@ref) for details on
+the simplifications that are applied.
+
+# Examples
+
+The generated markdown text will look similar to the following example where a function
+`f` defines three different methods:
+
+````markdown
+# Signatures
+
+```julia
+f(x, y; a, b...)
+```
+````
+"""
+const signatures = MethodSignatures()
+
+function format(::MethodSignatures, buf, doc)
+    local binding = doc.data[:binding]
+    local typesig = doc.data[:typesig]
+    local modname = doc.data[:module]
+    local func = Docs.resolve(binding)
+    local mt = filtermethods(func, typesig, modname; exact = true)
+    if !isempty(mt)
+        println(buf, "# Signatures\n")
+        println(buf, "```julia")
+        for method in mt
+            printmethod(buf, binding, func, method)
+            println(buf)
+        end
+        println(buf, "\n```\n")
     end
     return nothing
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -4,18 +4,25 @@
 #
 
 """
-Given a callable object `f` and a signature `sig` collect, filter, and sort the
-matching methods. All methods not defined within `mod` are discarded. Sorting
-is based on file name and line number.
+Given a callable object `f` and a signature `sig` collect, filter, and sort the matching
+methods. All methods not defined within `mod` are discarded. Sorting is based on file name
+and line number. When the `exact` keyword is set to `true` then only exact matching methods
+will be returned, not all subtypes as well.
 
-$(:methodlist)
+$(:signatures)
 """
-function filtermethods(f, sig, mod)
+function filtermethods(f, sig, mod; exact = false)
     local mt = sig == Union{} ? methods(f) : methods(f, sig)
     local results = Method[]
     for method in mt
         if getfield(method, :module)::Module == mod
-            push!(results, method)
+            if exact
+                if Base.tuple_type_tail(method.sig) == sig
+                    push!(results, method)
+                end
+            else
+                push!(results, method)
+            end
         end
     end
     local sorter = function(a, b)
@@ -29,7 +36,7 @@ end
 """
 Parse all docstrings defined within a module `mod`.
 
-$(:methodlist)
+$(:signatures)
 """
 function parsedocs(mod::Module)
     for (binding, multidoc) in Docs.meta(mod)
@@ -37,5 +44,105 @@ function parsedocs(mod::Module)
             Docs.parsedoc(docstr)
         end
     end
+end
+
+
+"""
+Print a simplified representation of a method signature to `buffer`.
+
+$(:signatures)
+
+Simplifications include:
+
+  * no `TypeVar`s;
+  * no types;
+  * no keyword default values;
+  * `?` printed where `#unused#` arguments are found.
+
+# Examples
+
+```julia
+f(x; a = 1, b...) = x
+sig = printmethod(Docs.Binding(Main, :f), f, first(methods(f)))
+```
+"""
+function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Method)
+    # TODO: print qualified?
+    print(buffer, binding.var)
+    print(buffer, "(")
+    join(buffer, arguments(method), ", ")
+    local kws = keywords(func, method)
+    if !isempty(kws)
+        print(buffer, "; ")
+        join(buffer, kws, ", ")
+    end
+    print(buffer, ")")
+    return buffer
+end
+
+printmethod(b, f, m) = takebuf_string(printmethod(IOBuffer(), b, f, m))
+
+
+"""
+Returns the list of keywords for a particular method `m` of a function `func`.
+
+$(:signatures)
+
+# Examples
+
+```julia
+f(x; a = 1, b...) = x
+kws = keywords(f, first(methods(f)))
+```
+"""
+function keywords(func, m::Method)
+    local table = methods(func).mt
+    if isdefined(table, :kwsorter)
+        local kwsorter = table.kwsorter
+        local signature = Base.tuple_type_cons(Vector{Any}, m.sig)
+        if method_exists(kwsorter, signature)
+            local method = which(kwsorter, signature)
+            if isdefined(method, :lambda_template)
+                local template = method.lambda_template
+                # `.slotnames` is a `Vector{Any}`. Convert it to the right type.
+                local args = map(Symbol, template.slotnames[(template.nargs + 1):end])
+                # Only return the usable symbols, not ones that aren't identifiers.
+                filter!(arg -> !contains(string(arg), "#"), args)
+                # Keywords *may* not be sorted correctly. We move the vararg one to the end.
+                local index = findfirst(arg -> endswith(string(arg), "..."), args)
+                if index > 0
+                    args[index], args[end] = args[end], args[index]
+                end
+                return args
+            end
+        end
+    end
+    return Symbol[]
+end
+
+
+"""
+Returns the list of arguments for a particular method `m`.
+
+$(:signatures)
+
+# Examples
+
+```julia
+f(x; a = 1, b...) = x
+args = arguments(first(methods(f)))
+```
+"""
+function arguments(m::Method)
+    if isdefined(m, :lambda_template)
+        local template = m.lambda_template
+        if isdefined(template, :slotnames)
+            local args = map(template.slotnames[1:template.nargs]) do arg
+                arg === Symbol("#unused#") ? "?" : arg
+            end
+            return filter(arg -> arg !== Symbol("#self#"), args)
+        end
+    end
+    return Symbol[]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,10 @@ type T
     c
 end
 
+immutable K
+    K(; a = 1) = new()
+end
+
 end
 
 @testset "" begin
@@ -80,16 +84,129 @@ end
         @test contains(str, " - ```")
         @test contains(str, "f(x) at ")
         @test contains(str, @__FILE__)
+
+        # Method signatures.
+        doc.data = Dict(
+            :binding => Docs.Binding(M, :f),
+            :typesig => Tuple{Any},
+            :module => M,
+        )
+        DSE.format(signatures, buf, doc)
+        str = takebuf_string(buf)
+        @test startswith(str, "# Signatures\n")
+        @test contains(str, "\n```julia\n")
+        @test contains(str, "\nf(x)\n")
+        @test contains(str, "\n```\n")
     end
     @testset "utilities" begin
-        list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any, Any}, DSE)
-        @test length(list) == 1
-        list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any, Any}, Base)
-        @test length(list) == 0
-        list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any}, DSE)
-        @test length(list) == 0
-        list = DSE.filtermethods(DSE.filtermethods, Union{}, DSE)
-        @test length(list) == 1
+        @testset "filtermethods" begin
+            let list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any, Any}, DSE)
+                @test length(list) == 1
+            end
+            let list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any, Any}, Base)
+                @test length(list) == 0
+            end
+            let list = DSE.filtermethods(DSE.filtermethods, Tuple{Any, Any}, DSE)
+                @test length(list) == 0
+            end
+            let list = DSE.filtermethods(DSE.filtermethods, Union{}, DSE)
+                @test length(list) == 1
+            end
+        end
+        @testset "keywords" begin
+            @test DSE.keywords(M.T, first(methods(M.T))) == Symbol[]
+            @test DSE.keywords(M.K, first(methods(M.K))) == [:a]
+            @test DSE.keywords(M.f, first(methods(M.f))) == Symbol[]
+            let f = (() -> ()),
+                m = first(methods(f))
+                @test DSE.keywords(f, m) == Symbol[]
+            end
+            let f = ((a) -> ()),
+                m = first(methods(f))
+                @test DSE.keywords(f, m) == Symbol[]
+            end
+            let f = ((; a = 1) -> ()),
+                m = first(methods(f))
+                @test DSE.keywords(f, m) == [:a]
+            end
+            let f = ((; a = 1, b = 2) -> ()),
+                m = first(methods(f))
+                @test DSE.keywords(f, m) == [:a, :b]
+            end
+            let f = ((; a...) -> ()),
+                m = first(methods(f))
+                @test DSE.keywords(f, m) == [Symbol("a...")]
+            end
+        end
+        @testset "arguments" begin
+            @test DSE.arguments(first(methods(M.T))) == [:a, :b, :c]
+            @test DSE.arguments(first(methods(M.K))) == Symbol[]
+            @test DSE.arguments(first(methods(M.f))) == [:x]
+            let m = first(methods(() -> ()))
+                @test DSE.arguments(m) == Symbol[]
+            end
+            let m = first(methods((a) -> ()))
+                @test DSE.arguments(m) == [:a]
+            end
+            let m = first(methods((; a = 1) -> ()))
+                @test DSE.arguments(m) == Symbol[]
+            end
+            let m = first(methods((x; a = 1, b = 2) -> ()))
+                @test DSE.arguments(m) == Symbol[:x]
+            end
+            let m = first(methods((; a...) -> ()))
+                @test DSE.arguments(m) == Symbol[]
+            end
+        end
+        @testset "printmethod" begin
+            let b = Docs.Binding(M, :T),
+                f = M.T,
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "T(a, b, c)"
+            end
+            let b = Docs.Binding(M, :K),
+                f = M.K,
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "K(; a)"
+            end
+            let b = Docs.Binding(M, :f),
+                f = M.f,
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "f(x)"
+            end
+            let b = Docs.Binding(Main, :f),
+                f = () -> (),
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "f()"
+            end
+            let b = Docs.Binding(Main, :f),
+                f = (a) -> (),
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "f(a)"
+            end
+            let b = Docs.Binding(Main, :f),
+                f = (; a = 1) -> (),
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "f(; a)"
+            end
+            let b = Docs.Binding(Main, :f),
+                f = (; a = 1, b = 2) -> (),
+                m = first(methods(f))
+                # Keywords are not ordered, so check for both combinations.
+                @test DSE.printmethod(b, f, m) in ("f(; a, b)", "f(; b, a)")
+            end
+            let b = Docs.Binding(Main, :f),
+                f = (; a...) -> (),
+                m = first(methods(f))
+                @test DSE.printmethod(b, f, m) == "f(; a...)"
+            end
+            let b = Docs.Binding(Main, :f),
+                f = (; a = 1, b = 2, c...) -> (),
+                m = first(methods(f))
+                # Keywords are not ordered, so check for both combinations.
+                @test DSE.printmethod(b, f, m) in ("f(; a, b, c...)", "f(; b, a, c...)")
+            end
+        end
     end
 end
 


### PR DESCRIPTION
Print "simplified" versions of method signatures. Simplifications include: no `TypeVar`s, types, or keyword values.