### PR TITLE
Expand introductory documentation for module

### DIFF
--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -1,7 +1,54 @@
 __precompile__(true)
 
 """
-Provides extensions to the Julia docsystem.
+*Extensions for the Julia docsystem.*
+
+# Introduction
+
+This package provides a collection of useful extensions for Julia's built-in docsystem.
+These are features that are still regarded as "experimental" and not yet mature enough to be
+considered for inclusion in `Base`, or that have sufficiently niche use cases that including
+them with the default Julia installation is not seen as valuable enough at this time.
+
+Currently `DocStringExtensions.jl` exports a collection of so-called "abbreviations", which
+can be used to add useful automatically generated information to docstrings. These include
+information such as:
+
+  * simplified method signatures;
+  * documentation for the individual fields of composite types;
+  * import and export lists for modules;
+  * and source-linked lists of methods applicable to a particular docstring.
+
+Details of the currently available abbreviations can be viewed in their individual
+docstrings listed below in the "Exports" section.
+
+# Examples
+
+In simple terms an abbreviation can be used by simply interpolating it into a suitable
+docstring. For example:
+
+```julia
+\"""
+A short summary of `func`...
+
+\$signatures
+
+where `x` and `y` should both be positive.
+
+# Details
+
+Some details about `func`...
+\"""
+func(x, y) = x + y
+```
+
+The resulting generated content can then be viewed via Julia's `?` mode or, if
+`Documenter.jl` is set up, the generated external documentation.
+
+The advantage of using [`signatures`](@ref) (and other abbreviations) is that docstrings are
+less likely to become out-of-sync with the surrounding code. Note though that references to
+the argument names `x` and `y` that have been manually embedded within the docstring are, of
+course, not updated automatically.
 
 $(exports)
 


### PR DESCRIPTION
Adds an introductory note related to the uses of the package as well as a simple example of how to use the `signatures` abbreviation.