### PR TITLE
Deduplicate methods

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -21,7 +21,7 @@ groups = methodgroups(f, Union{Tuple{Any}, Tuple{Any, Integer}}, Main; exact = f
 """
 function methodgroups(func, typesig, modname; exact = true)
     # Group methods by file and line number.
-    local methods = getmethods(func, typesig)
+    local methods = Set{Method}(getmethods(func, typesig))
     local groups = groupby(Tuple{Symbol, Int}, Vector{Method}, methods) do m
         (m.file, m.line), m
     end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -9,6 +9,11 @@ f(x) = x
 
 g(x = 1, y = 2, z = 3; kwargs...) = x
 
+typealias A{T} Union{Vector{T}, Matrix{T}}
+
+h_1(x::A) = x
+h_2(x::A{Int}) = x
+
 type T
     a
     b
@@ -218,6 +223,14 @@ end
             @test length(DSE.getmethods(M.f, Union{})) == 1
             @test length(DSE.getmethods(M.f, Tuple{})) == 0
             @test length(DSE.getmethods(M.f, Union{Tuple{}, Tuple{Any}})) == 1
+        end
+        @testset "methodgroups" begin
+            @test length(DSE.methodgroups(M.f, Tuple{Any}, M)) == 1
+            @test length(DSE.methodgroups(M.f, Tuple{Any}, M)[1]) == 1
+            @test length(DSE.methodgroups(M.h_1, Tuple{M.A}, M)) == 1
+            @test length(DSE.methodgroups(M.h_1, Tuple{M.A}, M)[1]) == 1
+            @test length(DSE.methodgroups(M.h_2, Tuple{M.A{Int}}, M)) == 1
+            @test length(DSE.methodgroups(M.h_2, Tuple{M.A{Int}}, M)[1]) == 1
         end
         @testset "alltypesigs" begin
             @test DSE.alltypesigs(Union{}) == Core.svec()


### PR DESCRIPTION
Fixes #14. `methods` when applied to functions with signatures that contain `Union` types with concrete parameters returns duplicated `Method` objects. Remove the dups by collecting into a `Set` instead of a `Vector`.