### PR TITLE
Fix error in method introspection on 0.6

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -214,6 +214,10 @@ if isdefined(Base, :LambdaInfo)
     has_method_source(m::Method) = isdefined(m, :lambda_template)
     get_method_source(m::Method) = m.lambda_template
     nargs(m::Method) = m.lambda_template.nargs
+elseif VERSION >= v"0.6.0-pre.alpha.244"
+    has_method_source(m::Method) = true
+    get_method_source(m::Method) = Base.uncompressed_ast(m)
+    nargs(m::Method) = m.nargs
 else
     has_method_source(m::Method) = isdefined(m, :source)
     get_method_source(m::Method) = m.source


### PR DESCRIPTION
Internal method compression was changed in JuliaLang/julia#20933 and is the cause of the current nightly failures. This PR should fix the issue here.