### PR TITLE
Update type declaration syntax for 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.8
+Compat 0.18

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -10,7 +10,7 @@ expanded automatically before parsing the text to markdown.
 
 $(:FIELDS)
 """
-abstract Abbreviation
+@compat abstract type Abbreviation end
 
 """
 $(:SIGNATURES)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -5,13 +5,15 @@ include("templates.jl")
 
 module M
 
+using Compat
+
 export f
 
 f(x) = x
 
 g(x = 1, y = 2, z = 3; kwargs...) = x
 
-typealias A{T} Union{Vector{T}, Matrix{T}}
+@compat const A{T} = Union{Vector{T}, Matrix{T}}
 
 h_1(x::A) = x
 h_2(x::A{Int}) = x
@@ -27,14 +29,14 @@ immutable K
 end
 
 
-abstract AbstractType <: Integer
+@compat abstract type AbstractType <: Integer end
 
 immutable CustomType{S, T <: Integer} <: Integer
 end
 
-bitstype 8 BitType8
+@compat primitive type BitType8 8 end
 
-bitstype 32 BitType32 <: Real
+@compat primitive type BitType32 <: Real 32 end
 
 end
 


### PR DESCRIPTION
This fixes the deprecation warnings on 0.6. Note though that the tests won't pass here until #27 is merged.