### PR TITLE
Drop support for 0.4 and 0.5, fix `type` and `immutable` depwarns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ os:
   - osx
 
 julia:
-  - 0.4
-  - 0.5
   - 0.6
   - nightly
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.6
 Compat 0.18

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
 
 # Don't build docs on version 0.4 since they will fail.
-VERSION < v"0.5.0-dev" && exit()
 
 using Documenter, DocStringExtensions
 

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -96,35 +96,6 @@ using Compat
 export @template, FIELDS, EXPORTS, METHODLIST, IMPORTS, SIGNATURES, TYPEDEF, DOCSTRING
 
 
-# Note:
-#
-# This package is installable on Julia 0.4, but will not provide any features. All the
-# exported "abbreviations" are just defined as `""` so that interpolating them into
-# docstrings will not be visible.
-#
-# Only on Julia 0.5 and above is the real package defined. "Abbreviations" will expand to
-# their correct definitions and all utility functions will be defined as well.
-#
-# This is done so that the package can be used with other packages that still support Julia
-# 0.4 without requiring this package as a "conditional" dependancy. The effects of this
-# package will be invisible to users on 0.4.
-#
-# Once `DocStringExtensions` drops support for Julia 0.4 this condition can be removed.
-#
-if VERSION < v"0.5.0-dev"
-
-include("mock.jl")
-
-else # VERSION < v"0.5.0-dev"
-
-# Compat.
-
-if VERSION < v"0.6.0-dev.1254"
-    takebuf_str(b) = takebuf_string(b)
-else
-    takebuf_str(b) = String(take!(b))
-end
-
 # Includes.
 
 include("utilities.jl")
@@ -152,7 +123,5 @@ let λ = s -> isa(s, Symbol) ? getfield(DocStringExtensions, s) : s
 end
 
 __init__() = (hook!(template_hook); nothing)
-
-end # VERSION < v"0.5.0-dev"
 
 end # module

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -10,7 +10,7 @@ expanded automatically before parsing the text to markdown.
 
 $(:FIELDS)
 """
-@compat abstract type Abbreviation end
+abstract type Abbreviation end
 
 """
 $(:SIGNATURES)

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -39,7 +39,7 @@ The singleton type for [`FIELDS`](@ref) abbreviations.
 
 $(:FIELDS)
 """
-immutable TypeFields <: Abbreviation end
+struct TypeFields <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) to include the names of the fields of a type as well as any
@@ -102,7 +102,7 @@ The singleton type for [`EXPORTS`](@ref) abbreviations.
 
 $(:FIELDS)
 """
-immutable ModuleExports <: Abbreviation end
+struct ModuleExports <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) to include all the exported names of a module is a sorted list of
@@ -156,7 +156,7 @@ The singleton type for [`IMPORTS`](@ref) abbreviations.
 
 $(:FIELDS)
 """
-immutable ModuleImports <: Abbreviation end
+struct ModuleImports <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) to include all the imported modules in a sorted list.
@@ -198,7 +198,7 @@ The singleton type for [`METHODLIST`](@ref) abbreviations.
 
 $(:FIELDS)
 """
-immutable MethodList <: Abbreviation end
+struct MethodList <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) for including a list of all the methods that match a documented
@@ -265,7 +265,7 @@ The singleton type for [`SIGNATURES`](@ref) abbreviations.
 
 $(:FIELDS)
 """
-immutable MethodSignatures <: Abbreviation end
+struct MethodSignatures <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) for including a simplified representation of all the method
@@ -312,14 +312,14 @@ end
 """
 The singleton type for [`TYPEDEF`](@ref) abbreviations.
 """
-immutable TypeDefinition <: Abbreviation end
+struct TypeDefinition <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) for including a summary of the signature of a type definition.
 Some of the following information may be included in the output:
 
   * whether the object is an `abstract` type or a `bitstype`;
-  * mutability (either `type` or `immutable` is printed);
+  * mutability (either `type` or `struct` is printed);
   * the unqualified name of the type;
   * any type parameters;
   * the supertype of the type if it is not `Any`.
@@ -332,7 +332,7 @@ The generated output for a type definition such as:
 \"""
 \$(TYPEDEF)
 \"""
-immutable MyType{S, T <: Integer} <: AbstractArray
+struct MyType{S, T <: Integer} <: AbstractArray
     # ...
 end
 ```
@@ -341,7 +341,7 @@ will look similar to the following:
 
 ````markdown
 ```julia
-immutable MyType{S, T<:Integer} <: AbstractArray
+struct MyType{S, T<:Integer} <: AbstractArray
 ```
 ````
 
@@ -362,7 +362,7 @@ function format(::TypeDefinition, buf, doc)
         elseif isabstracttype(object)
             print(buf, "abstract ")
         else
-            print(buf, object.mutable ? "type " : "immutable ")
+            print(buf, object.mutable ? "type " : "struct ")
         end
         print(buf, object.name.name)
         if !isempty(object.parameters)
@@ -383,7 +383,7 @@ end
 """
 The singleton type for [`DOCSTRING`](@ref) abbreviations.
 """
-immutable DocStringTemplate <: Abbreviation end
+struct DocStringTemplate <: Abbreviation end
 
 """
 An [`Abbreviation`](@ref) used in [`@template`](@ref) definitions to represent the location

--- a/src/mock.jl
+++ b/src/mock.jl
@@ -1,7 +1,0 @@
-# Mock definitions for 0.4.
-
-const FIELDS, EXPORTS, METHODLIST, IMPORTS, SIGNATURES, TYPEDEF, DOCSTRING =
-    "", "", "", "", "", "", ""
-
-macro template(expr) nothing end
-

--- a/src/templates.jl
+++ b/src/templates.jl
@@ -1,7 +1,5 @@
-
-const (expander, setter!) = isdefined(Base, :DocBootStrap) ?
-    (Base.DocBootStrap._expand_, Base.DocBootStrap.setexpand!) : # Julia 0.4
-    (Core.atdoc, Core.atdoc!)                                    # Julia 0.5+
+const expander = Core.atdoc
+const setter! = Core.atdoc!
 
 """
 $(:SIGNATURES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using DocStringExtensions
 using Base.Test
 
-VERSION < v"0.5.0-dev" ? warn("Untestable on Julia 0.4.") : include("tests.jl")
+include("tests.jl")
 

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -32,8 +32,8 @@ using DocStringExtensions
 "constant `K`"
 const K = 1
 
-"type `T`"
-type T end
+"mutable struct `T`"
+mutable struct T end
 
 "method `f`"
 f(x) = x
@@ -63,8 +63,8 @@ module InnerModule
     "constant `K`"
     const K = 1
 
-    "type `T`"
-    type T end
+    "mutable struct `T`"
+    mutable struct T end
 
     "method `f`"
     f(x) = x
@@ -82,8 +82,8 @@ module OtherModule
     @template TYPES = TemplateTests
     @template MACROS = TemplateTests.InnerModule
 
-    "type `T`"
-    type T end
+    "mutable struct `T`"
+    mutable struct T end
 
     "macro `@m`"
     macro m(x) end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -18,7 +18,7 @@ g(x = 1, y = 2, z = 3; kwargs...) = x
 h_1(x::A) = x
 h_2(x::A{Int}) = x
 
-type T
+mutable struct T
     a
     b
     c

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -24,14 +24,14 @@ type T
     c
 end
 
-immutable K
+struct K
     K(; a = 1) = new()
 end
 
 
 @compat abstract type AbstractType <: Integer end
 
-immutable CustomType{S, T <: Integer} <: Integer
+struct CustomType{S, T <: Integer} <: Integer
 end
 
 @compat primitive type BitType8 8 end
@@ -155,7 +155,7 @@ end
             DSE.format(TYPEDEF, buf, doc)
             str = DSE.takebuf_str(buf)
             @test contains(str, "\n```julia\n")
-            @test contains(str, "\nimmutable CustomType{S, T<:Integer} <: Integer\n")
+            @test contains(str, "\nstruct CustomType{S, T<:Integer} <: Integer\n")
             @test contains(str, "\n```\n")
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -13,7 +13,7 @@ f(x) = x
 
 g(x = 1, y = 2, z = 3; kwargs...) = x
 
-@compat const A{T} = Union{Vector{T}, Matrix{T}}
+const A{T} = Union{Vector{T}, Matrix{T}}
 
 h_1(x::A) = x
 h_2(x::A{Int}) = x
@@ -29,14 +29,14 @@ struct K
 end
 
 
-@compat abstract type AbstractType <: Integer end
+abstract type AbstractType <: Integer end
 
 struct CustomType{S, T <: Integer} <: Integer
 end
 
-@compat primitive type BitType8 8 end
+primitive type BitType8 8 end
 
-@compat primitive type BitType32 <: Real 32 end
+primitive type BitType32 <: Real 32 end
 
 end
 
@@ -56,13 +56,13 @@ end
                 :typesig => Union{},
             )
             DSE.format(IMPORTS, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n  - `Base`\n")
             @test contains(str, "\n  - `Core`\n")
 
             # Module exports.
             DSE.format(EXPORTS, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n  - [`f`](@ref)\n")
         end
 
@@ -75,7 +75,7 @@ end
                 ),
             )
             DSE.format(FIELDS, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "  - `a`")
             @test contains(str, "  - `b`")
             @test contains(str, "  - `c`")
@@ -90,7 +90,7 @@ end
                 :module => M,
             )
             DSE.format(METHODLIST, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "```julia")
             @test contains(str, "f(x)")
             @test contains(str, "[`$(joinpath("DocStringExtensions", "test", "tests.jl"))")
@@ -103,7 +103,7 @@ end
                 :module => M,
             )
             DSE.format(SIGNATURES, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\nf(x)\n")
             @test contains(str, "\n```\n")
@@ -114,7 +114,7 @@ end
                 :module => M,
             )
             DSE.format(SIGNATURES, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\ng()\n")
             @test contains(str, "\ng(x)\n")
@@ -126,7 +126,7 @@ end
                 :module => M,
             )
             DSE.format(SIGNATURES, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\ng()\n")
             @test contains(str, "\ng(x)\n")
@@ -142,7 +142,7 @@ end
                 :module => M,
             )
             DSE.format(TYPEDEF, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\nabstract AbstractType <: Integer\n")
             @test contains(str, "\n```\n")
@@ -153,7 +153,7 @@ end
                 :module => M,
             )
             DSE.format(TYPEDEF, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\nstruct CustomType{S, T<:Integer} <: Integer\n")
             @test contains(str, "\n```\n")
@@ -164,7 +164,7 @@ end
                 :module => M,
             )
             DSE.format(TYPEDEF, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\nbitstype 8 BitType8\n")
             @test contains(str, "\n```\n")
@@ -175,7 +175,7 @@ end
                 :module => M,
             )
             DSE.format(TYPEDEF, buf, doc)
-            str = DSE.takebuf_str(buf)
+            str = String(take!(buf))
             @test contains(str, "\n```julia\n")
             @test contains(str, "\nbitstype 32 BitType32 <: Real")
             @test contains(str, "\n```\n")


### PR DESCRIPTION
Awaiting https://github.com/JuliaDocs/DocStringExtensions.jl/issues/35 decision.

BTW, I also tried to fix the `current_module` depwarns using `@__MODULE__`, but that didn't work straight away; not sure why yet.

Closes #35