### PR TITLE
Fix SIGNATURES for methods with UnionAll arguments

### DIFF
--- a/src/templates.jl
+++ b/src/templates.jl
@@ -127,7 +127,7 @@ function expression_type(ex::Expr)
         :TYPES
     elseif Meta.isexpr(ex, :macro)
         :MACROS
-    elseif Meta.isexpr(ex, [:function, :(=)]) && Meta.isexpr(ex.args[1], :call)
+    elseif Meta.isexpr(ex, [:function, :(=)]) && Meta.isexpr(ex.args[1], :call) || (Meta.isexpr(ex.args[1], :where) && Meta.isexpr(ex.args[1].args[1], :call))
         :METHODS
     elseif Meta.isexpr(ex, :function)
         :FUNCTIONS

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -122,7 +122,7 @@ Returns a `Vector` of the `Tuple` types contained in `sig`.
 """
 function alltypesigs(sig)::Vector{Any}
     if sig == Union{}
-        return Any[]
+        Any[]
     elseif isa(sig, Union)
         uniontypes(sig)
     elseif isa(sig, UnionAll)

--- a/test/templates.jl
+++ b/test/templates.jl
@@ -38,6 +38,9 @@ mutable struct T end
 "method `f`"
 f(x) = x
 
+"method `g`"
+g(::Type{T}) where {T} = T # Issue 32
+
 "macro `@m`"
 macro m(x) end
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -187,6 +187,7 @@ end
             @test contains(fmt(:(TemplateTests.K)), "(DEFAULT)")
             @test contains(fmt(:(TemplateTests.T)), "(TYPES)")
             @test contains(fmt(:(TemplateTests.f)), "(METHODS, MACROS)")
+            @test contains(fmt(:(TemplateTests.g)), "(METHODS, MACROS)")
             @test contains(fmt(:(TemplateTests.@m)), "(METHODS, MACROS)")
 
             @test contains(fmt(:(TemplateTests.InnerModule.K)), "(DEFAULT)")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -17,6 +17,7 @@ const A{T} = Union{Vector{T}, Matrix{T}}
 
 h_1(x::A) = x
 h_2(x::A{Int}) = x
+h_3(x::A{T}) where {T} = x
 
 mutable struct T
     a
@@ -297,6 +298,9 @@ end
             @test length(DSE.getmethods(M.f, Union{})) == 1
             @test length(DSE.getmethods(M.f, Tuple{})) == 0
             @test length(DSE.getmethods(M.f, Union{Tuple{}, Tuple{Any}})) == 1
+            @test length(DSE.getmethods(M.h_3, Tuple{M.A{Int}})) == 1
+            @test length(DSE.getmethods(M.h_3, Tuple{Vector{Int}})) == 1
+            @test length(DSE.getmethods(M.h_3, Tuple{Array{Int, 3}})) == 0
         end
         @testset "methodgroups" begin
             @test length(DSE.methodgroups(M.f, Tuple{Any}, M)) == 1
@@ -305,11 +309,13 @@ end
             @test length(DSE.methodgroups(M.h_1, Tuple{M.A}, M)[1]) == 1
             @test length(DSE.methodgroups(M.h_2, Tuple{M.A{Int}}, M)) == 1
             @test length(DSE.methodgroups(M.h_2, Tuple{M.A{Int}}, M)[1]) == 1
+            @test length(DSE.methodgroups(M.h_3, Tuple{M.A}, M)[1]) == 1
         end
         @testset "alltypesigs" begin
             @test DSE.alltypesigs(Union{}) == Any[]
             @test DSE.alltypesigs(Union{Tuple{}}) == Any[Tuple{}]
             @test DSE.alltypesigs(Tuple{}) == Any[Tuple{}]
+            @test DSE.alltypesigs(Type{T} where {T}) == Any[Type{T} where T]
         end
         @testset "groupby" begin
             let groups = DSE.groupby(Int, Vector{Int}, collect(1:10)) do each


### PR DESCRIPTION
Fixes  #32.

~~I must say I don't completely understand the test set. Could you show me how to add more of an integration test of the functionality of `$(SIGNATURES)` for a function that takes `UnionAll` arguments?~~