### PR TITLE
Rename loop variable to avoid conflict

### DIFF
--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -134,12 +134,12 @@ function format(::ModuleExports, buf, doc)
     if !isempty(exports)
         println(buf)
         # Sorting ignores the `@` in macro names and sorts them in with others.
-        for name in sort(exports, by = s -> lstrip(string(s), '@'))
+        for sym in sort(exports, by = s -> lstrip(string(s), '@'))
             # Skip the module itself, since that's always exported.
-            name === module_name(object) && continue
+            sym === module_name(object) && continue
             # We print linked names using Documenter.jl cross-reference syntax
             # for ease of integration with that package.
-            println(buf, "  - [`", name, "`](@ref)")
+            println(buf, "  - [`", sym, "`](@ref)")
         end
         println(buf)
     end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/25622 introduces a new function called `name` that replaces `module_name` and a couple other things. This package is using `name` as a loop variable and comparing that against the result of (what will be) a call to the `name` function, which results in an error when building documentation. This PR simply renames the loop variable to avoid this conflict.

It would be great if we could get this in ASAP, since it's blocking the Base PR.