### PR TITLE
Use Core.eval instead of eval

### DIFF
--- a/src/templates.jl
+++ b/src/templates.jl
@@ -82,7 +82,7 @@ end
 
 function template(source::LineNumberNode, mod::Module, tuple::Expr, docstr::Union{Symbol, Expr})
     Meta.isexpr(tuple, :tuple) || error("invalid `@template` syntax on LHS.")
-    isdefined(mod, TEMP_SYM) || eval(mod, :(const $(TEMP_SYM) = $(Dict{Symbol, Vector}())))
+    isdefined(mod, TEMP_SYM) || Core.eval(mod, :(const $(TEMP_SYM) = $(Dict{Symbol, Vector}())))
     local block = Expr(:block)
     for category in tuple.args
         local key = Meta.quot(category)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -169,8 +169,16 @@ $(:SIGNATURES)
 Remove the `Pkg.dir` part of a file `path` if it exists.
 """
 function cleanpath(path::AbstractString)
-    local pkgdir = joinpath(Compat.Pkg.dir(), "")
-    return startswith(path, pkgdir) ? first(split(path, pkgdir; keep = false)) : path
+    @static if VERSION >= v"0.7.0-DEV.5183"
+        for depot in DEPOT_PATH
+            pkgdir = joinpath(depot, "")
+            startswith(path, pkgdir) && return first(split(path, pkgdir, keepempty=false))
+        end
+        return path
+    else
+        pkgdir = joinpath(Compat.Pkg.dir(), "")
+        return startswith(path, pkgdir) ? first(split(path, pkgdir; keep = false)) : path
+    end
 end
 
 """

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -145,7 +145,7 @@ end
             str = String(take!(buf))
             @test occursin("```julia", str)
             @test occursin("f(x)", str)
-            @test occursin("[`$(joinpath("DocStringExtensions", "test", "tests.jl"))", str)
+            @test occursin(joinpath("test", "tests.jl"), str)
         end
 
         @testset "method signatures" begin


### PR DESCRIPTION
This fixes a deprecation warning on Julia 0.7 and is fully backwards compatible with 0.6.