### PR TITLE
Use VMs instead of container-based builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ os:
   - linux
   - osx
 
-sudo: false
-
 julia:
   - 0.7
   - 1.0


### PR DESCRIPTION
Ref: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration