### PR TITLE
Fix typed signatures parametric types

### DIFF
--- a/docs/Showcase/src/Showcase.jl
+++ b/docs/Showcase/src/Showcase.jl
@@ -70,6 +70,60 @@ $(TYPEDSIGNATURES)
 foo(x::AbstractString) = nothing
 
 
+## Methods with type parameters
+
+"""
+A method for [`$(FUNCTIONNAME)`](@ref), with type parameters. Original declaration:
+
+```julia
+bar(x::AbstractArray{T}, y::T) where {T <: Integer} = nothing
+```
+
+And the result from [`TYPEDSIGNATURES`](@ref) abbreviation:
+
+$(TYPEDSIGNATURES)
+
+For comparison, [`SIGNATURES`](@ref) abbreviation:
+
+$(SIGNATURES)
+"""
+bar(x::AbstractArray{T}, y::T) where {T <: Integer} = nothing
+
+"""
+A method for [`$(FUNCTIONNAME)`](@ref), with type parameters. Original declaration:
+
+```julia
+bar(x::AbstractArray{T}, ::String) where {T <: Integer} = x
+```
+
+And the result from [`TYPEDSIGNATURES`](@ref) abbreviation:
+
+$(TYPEDSIGNATURES)
+
+For comparison, [`SIGNATURES`](@ref) abbreviation:
+
+$(SIGNATURES)
+"""
+bar(x::AbstractArray{T}, ::String) where {T <: Integer} = x
+
+"""
+A method for [`$(FUNCTIONNAME)`](@ref), with type parameters. Original declaration:
+
+```julia
+bar(x::AbstractArray{T}, y::U) where {T <: Integer, U <: AbstractString} = 0
+```
+
+And the result from [`TYPEDSIGNATURES`](@ref) abbreviation:
+
+$(TYPEDSIGNATURES)
+
+For comparison, [`SIGNATURES`](@ref) abbreviation:
+
+$(SIGNATURES)
+"""
+bar(x::AbstractArray{T}, y::U) where {T <: Integer, U <: AbstractString} = 0
+
+
 """
 The [`TYPEDEF`](@ref) abbreviation includes the type signature:
 

--- a/docs/src/showcase.md
+++ b/docs/src/showcase.md
@@ -21,6 +21,18 @@ foo(::Int)
 foo(::String)
 ```
 
+### Type parameters
+
+[`TYPEDSIGNATURES`](@ref) can also handle type parameters. However, the resulting signatures
+may not be as clean as in the code since they have to be reconstructed from Julia's internal
+representation:
+
+```@docs
+bar(x::AbstractArray{T}, y::T) where {T <: Integer}
+bar(x::AbstractArray{T}, ::String) where {T <: Integer}
+bar(x::AbstractArray{T}, y::U) where {T <: Integer, U <: AbstractString}
+```
+
 ## Types
 
 ```@docs

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -378,11 +378,11 @@ function format(::TypedMethodSignatures, buf, doc)
         println(buf)
         println(buf, "```julia")
         for (i, method) in enumerate(group)
-            if i == length(group) || typesig isa UnionAll
-                t = find_tuples(typesig)[end]
-            else
-                t = typesig.a
-                typesig = typesig.b
+            N = length(arguments(method))
+            tuples = find_tuples(typesig)
+            t = tuples[findfirst(t -> t isa DataType && string(t.name) == "Tuple" && length(t.types) == N, tuples)]
+            if t == nothing
+                t = typesig
             end
             printmethod(buf, binding, func, method, t)
             println(buf)

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -380,7 +380,11 @@ function format(::TypedMethodSignatures, buf, doc)
         for (i, method) in enumerate(group)
             N = length(arguments(method))
             tuples = find_tuples(typesig)
-            t = tuples[findfirst(t -> t isa DataType && string(t.name) == "Tuple" && length(t.types) == N, tuples)]
+            if Sys.iswindows()
+                t = tuples[findlast(t -> t isa DataType && string(t.name) == "Tuple" && length(t.types) == N, tuples)]
+            else
+                t = tuples[findfirst(t -> t isa DataType && string(t.name) == "Tuple" && length(t.types) == N, tuples)]
+            end
             if t == nothing
                 t = typesig
             end

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -382,9 +382,11 @@ function format(::TypedMethodSignatures, buf, doc)
                 for (i, method) in enumerate(group)
                     if i == length(group)
                         t = typesig
-                    else
+                    elseif !(typesig isa UnionAll)
                         t = typesig.a
                         typesig = typesig.b
+                    else
+                        t = typesig
                     end
                     printmethod(buf, binding, func, method, t)
                     println(buf)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -357,7 +357,7 @@ function arguments(m::Method)
     local template = get_method_source(m)
     if isdefined(template, :slotnames)
         local args = map(template.slotnames[1:nargs(m)]) do arg
-            arg === Symbol("#unused#") ? "?" : arg
+            arg === Symbol("#unused#") ? "" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -298,6 +298,9 @@ $(:SIGNATURES)
 This function takes a UnionAll and converts it to a string
 """
 function type_to_string(t::UnionAll)
+    # TODO: implement better stringification of UnionAll
+    # Current implementation defaults to Julia's show method
+    # This takes `Array{<:Number, 1}` and `returns Array{var"#s2",1} where var"#s2"<:Number`
     return "$(t)"
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -246,8 +246,10 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     print(buffer, "(")
     local args = arguments(method)
     for (i, sym) in enumerate(args)
-        if typesig isa UnionAll
+        if typesig isa UnionAll && !(typesig.body isa UnionAll)
             t = typesig.body.a.types[1]
+        elseif typesig isa UnionAll && typesig.body isa UnionAll
+            t = typesig.body.body.a.types[1]
         else
             t = typesig.types[i]
         end
@@ -262,8 +264,10 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
         join(buffer, kws, ", ")
     end
     print(buffer, ")")
-    if typesig isa UnionAll
+    if typesig isa UnionAll && !(typesig.body isa UnionAll)
         t = typesig.body.a
+    elseif typesig isa UnionAll && (typesig.body isa UnionAll)
+        t = typesig.body.body.a
     else
         t = typesig
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -317,6 +317,7 @@ simplifications include:
   * no `TypeVar`s;
   * no types;
   * no keyword default values;
+  * `?` printed where `#unused#` arguments are found.
 
 # Examples
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -272,23 +272,6 @@ end
 """
 $(:SIGNATURES)
 
-This function converts a typevar element to a string
-"""
-function typevar_to_string(typevar::TypeVar)
-    s = ""
-    if typevar.lb != Union{}
-        s = "$(typevar.lb)<:"
-    end
-    s = "$s$(string(typevar.name))"
-    if typevar.ub != Union{}
-        s = "$s<:$(typevar.ub)"
-    end
-    return "where $s"
-end
-
-"""
-$(:SIGNATURES)
-
 This function takes a DataType and converts it to a string
 """
 function type_to_string(d::DataType)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -222,6 +222,16 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     return buffer
 end
 
+"""
+$(:SIGNATURES)
+
+Find the tuples that represent all the types of all the method arguments and return a DataType Vector
+
+Tuple{String,Number,Int} -> DataType[Tuple{String,Number,Int}]
+
+Union{Tuple{Int64}, Tuple{U}, Tuple{T}, Tuple{Int64,T}, Tuple{Int64,T,U}} where U where
+T -> DataType[Tuple{Int64}, Tuple{U}, Tuple{T}, Tuple{Int64,T}, Tuple{Int64,T,U}]
+"""
 function find_tuples(typesig)
     if typesig isa UnionAll
         return find_tuples(typesig.body)
@@ -232,6 +242,11 @@ function find_tuples(typesig)
     end
 end
 
+"""
+$(:SIGNATURES)
+
+This function takes any type signature that returns an Vector of `TypeVar`
+"""
 function find_vars(typesig)
     if typesig isa UnionAll
         return [typesig.var, find_vars(typesig.body)...]
@@ -240,6 +255,11 @@ function find_vars(typesig)
     end
 end
 
+"""
+$(:SIGNATURES)
+
+This function converts a typevar element to a string
+"""
 function typevar_to_string(typevar::TypeVar)
     s = ""
     if typevar.lb != Union{}
@@ -276,7 +296,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     print(buffer, "(")
     local args = arguments(method)
     for (i, sym) in enumerate(args)
-        t = find_tuples(typesig)[end].types[i]
+        t = typesig.types[i]
         print(buffer, "$sym::$t")
         if i != length(args)
             print(buffer, ", ")
@@ -293,8 +313,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     #    s = join(typevar_to_string.(find_vars(typesig)), " ")
     #    print(buffer, " ", s)
     # end
-    t = find_tuples(typesig)[end]
-    rt = Base.return_types(func, t)
+    rt = Base.return_types(func, typesig)
     if length(rt) >= 1 && rt[1] !== Nothing && rt[1] !== Union{}
         print(buffer, " -> $(rt[1])")
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -416,7 +416,7 @@ function arguments(m::Method)
     local template = get_method_source(m)
     if isdefined(template, :slotnames)
         local args = map(template.slotnames[1:nargs(m)]) do arg
-            arg === Symbol("#unused#") ? "" : arg
+            arg === Symbol("#unused#") ? "?" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -313,7 +313,6 @@ simplifications include:
   * no `TypeVar`s;
   * no types;
   * no keyword default values;
-  * `?` printed where `#unused#` arguments are found.
 
 # Examples
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -233,10 +233,31 @@ when the docstring applies to multiple methods (e.g. when default positional arg
 are used and define multiple methods at once), they are combined together as union of `Tuple`
 types.
 
-Tuple{String,Number,Int} -> DataType[Tuple{String,Number,Int}]
+```jldoctest; setup = :(using DocStringExtensions)
+julia> DocStringExtensions.find_tuples(Tuple{String,Number,Int})
+1-element Array{DataType,1}:
+ Tuple{String,Number,Int64}
 
-Union{Tuple{Int64}, Tuple{U}, Tuple{T}, Tuple{Int64,T}, Tuple{Int64,T,U}} where U where
-T -> DataType[Tuple{Int64}, Tuple{U}, Tuple{T}, Tuple{Int64,T}, Tuple{Int64,T,U}]
+julia> DocStringExtensions.find_tuples(Tuple{T} where T <: Integer)
+1-element Array{DataType,1}:
+ Tuple{T<:Integer}
+
+julia> s = Union{
+         Tuple{Int64},
+         Tuple{U},
+         Tuple{T},
+         Tuple{Int64,T},
+         Tuple{Int64,T,U}
+       } where U where T;
+
+julia> DocStringExtensions.find_tuples(s)
+5-element Array{DataType,1}:
+ Tuple{Int64}
+ Tuple{U}
+ Tuple{T}
+ Tuple{Int64,T}
+ Tuple{Int64,T,U}
+```
 """
 function find_tuples(typesig)
     if typesig isa UnionAll

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -300,6 +300,15 @@ function type_to_string(t::UnionAll)
 end
 
 """
+$(:SIGNATURES)
+
+This function takes a Union and converts it to a string
+"""
+function type_to_string(t::Union)
+    return "$(t)"
+end
+
+"""
 $(:TYPEDSIGNATURES)
 
 Print a simplified representation of a method signature to `buffer`. Some of these
@@ -323,6 +332,8 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     local args = arguments(method)
     local where_syntax = []
     for (i, sym) in enumerate(args)
+        # TODO: parametric types may not be just `TypeVar`
+        # Current implementation will only add where clauses for arguments that are `TypeVar`
         if typesig.types[i] isa TypeVar
             push!(where_syntax, typesig.types[i])
         end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -272,21 +272,6 @@ end
 """
 $(:SIGNATURES)
 
-This function takes any type signature that returns an Vector of `TypeVar`
-"""
-function find_vars(typesig)
-    if typesig isa UnionAll
-        return [find_vars(typesig.body)...]
-    elseif typesig isa TypeVar
-        return [typesig]
-    else
-        return []
-    end
-end
-
-"""
-$(:SIGNATURES)
-
 This function converts a typevar element to a string
 """
 function typevar_to_string(typevar::TypeVar)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -225,7 +225,13 @@ end
 """
 $(:SIGNATURES)
 
-Find the tuples that represent all the types of all the method arguments and return a DataType Vector
+Converts a method signature (or a union of several signatures) in a vector of (single)
+signatures.
+
+This is used for decoding the method signature that a docstring is paired with. In the case
+when the docstring applies to multiple methods (e.g. when default positional argument values
+are used and define multiple methods at once), they are combined together as union of `Tuple`
+types.
 
 Tuple{String,Number,Int} -> DataType[Tuple{String,Number,Int}]
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -232,6 +232,26 @@ function find_tuples(typesig)
     end
 end
 
+function find_vars(typesig)
+    if typesig isa UnionAll
+        return [typesig.var, find_vars(typesig.body)...]
+    else
+        return []
+    end
+end
+
+function typevar_to_string(typevar::TypeVar)
+    s = ""
+    if typevar.lb != Union{}
+        s = "$(typevar.lb) <: "
+    end
+    s = "$s$(string(typevar.name))"
+    if typevar.ub != Union{}
+        s = "$s <: $(typevar.ub)"
+    end
+    return "where $s"
+end
+
 """
 $(:TYPEDSIGNATURES)
 
@@ -268,6 +288,11 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
         join(buffer, kws, ", ")
     end
     print(buffer, ")")
+    # TODO: Should we optionally support the `where` syntax?
+    # if typesig isa UnionAll
+    #    s = join(typevar_to_string.(find_vars(typesig)), " ")
+    #    print(buffer, " ", s)
+    # end
     t = find_tuples(typesig)[end]
     rt = Base.return_types(func, t)
     if length(rt) >= 1 && rt[1] !== Nothing && rt[1] !== Union{}

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -371,7 +371,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     end
     print(buffer, ")")
     for t in reverse(where_syntax)
-        s = typevar_to_string(t)
+        s = "where $t" # t is a TypeVar
         print(buffer, " ", s)
     end
     rt = Base.return_types(func, typesig)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -270,45 +270,6 @@ function find_tuples(typesig)
 end
 
 """
-$(:SIGNATURES)
-
-This function takes a DataType and converts it to a string
-"""
-function type_to_string(d::DataType)
-    return "$d"
-end
-
-"""
-$(:SIGNATURES)
-
-This function takes a TypeVar and converts it to a string
-"""
-function type_to_string(tv::TypeVar)
-    return "$(tv.name)"
-end
-
-"""
-$(:SIGNATURES)
-
-This function takes a UnionAll and converts it to a string
-"""
-function type_to_string(t::UnionAll)
-    # TODO: implement better stringification of UnionAll
-    # Current implementation defaults to Julia's show method
-    # This takes `Array{<:Number, 1}` and `returns Array{var"#s2",1} where var"#s2"<:Number`
-    return "$(t)"
-end
-
-"""
-$(:SIGNATURES)
-
-This function takes a Union and converts it to a string
-"""
-function type_to_string(t::Union)
-    return "$(t)"
-end
-
-"""
 $(:TYPEDSIGNATURES)
 
 Print a simplified representation of a method signature to `buffer`. Some of these
@@ -333,12 +294,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     local args = arguments(method)
     local where_syntax = []
     for (i, sym) in enumerate(args)
-        # TODO: parametric types may not be just `TypeVar`
-        # Current implementation will only add where clauses for arguments that are `TypeVar`
-        if typesig.types[i] isa TypeVar
-            push!(where_syntax, typesig.types[i])
-        end
-        t = type_to_string(typesig.types[i])
+        t = typesig.types[i]
         print(buffer, "$sym::$t")
         if i != length(args)
             print(buffer, ", ")
@@ -350,10 +306,6 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
         join(buffer, kws, ", ")
     end
     print(buffer, ")")
-    for t in reverse(unique(where_syntax))
-        s = "where $t" # t is a TypeVar
-        print(buffer, " ", s)
-    end
     rt = Base.return_types(func, typesig)
     if length(rt) >= 1 && rt[1] !== Nothing && rt[1] !== Union{}
         print(buffer, " -> $(rt[1])")

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -350,7 +350,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
         join(buffer, kws, ", ")
     end
     print(buffer, ")")
-    for t in reverse(where_syntax)
+    for t in reverse(unique(where_syntax))
         s = "where $t" # t is a TypeVar
         print(buffer, " ", s)
     end

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -27,7 +27,8 @@ k_1(x::String, y::Int = 0, z::T = zero(T)) where T <: Number = x
 k_2(x::String, y::U = 0, z::T = zero(T)) where T <: Number where U <: Complex = x
 k_3(x, y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
 k_4(::String, ::Int = 0) = nothing
-k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = nothing
+k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = x
+k_6(x::Vector{T}) where T <: Number = x
 
 mutable struct T
     a

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -25,6 +25,7 @@ j_1(x; y = x) = x * y # one argument, one keyword argument
 k_1(x::String, y::Int = 0, z::T = zero(T)) where T <: Number = x
 k_2(x::String, y::U = 0, z::T = zero(T)) where T <: Number where U <: Complex = x
 k_3(x, y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
+k_4(::String, ::Int = 0) = nothing
 
 
 mutable struct T

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -23,7 +23,7 @@ i_4(x; y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
 j_1(x, y) = x * y # two arguments, no keyword arguments
 j_1(x; y = x) = x * y # one argument, one keyword argument
 
-k_1(x::String, y::Int = 0, z::T = zero(Number)) where T <: Number = x
+k_1(x::String, y::T = 0, z::T = zero(T)) where T <: Number = x
 k_2(x::String, y::U, z::T) where T <: Number where U <: Complex = x
 k_3(x, y::T, z::U) where {T, U} = x + y + z
 k_4(::String, ::Int = 0) = nothing

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -30,6 +30,8 @@ k_4(::String, ::Int = 0) = nothing
 k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = x
 k_6(x::Vector{T}) where T <: Number = x
 k_7(x::Union{T,Nothing}, y::T = zero(T)) where {T <: Number} = x
+k_8(x) = x
+k_9(x::T where T<:Any) = x
 
 mutable struct T
     a

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -13,6 +13,7 @@ const A{T} = Union{Vector{T}, Matrix{T}}
 h_1(x::A) = x
 h_2(x::A{Int}) = x
 h_3(x::A{T}) where {T} = x
+h_4(x, ::Int, z) = x
 
 i_1(x; y = x) = x * y
 i_2(x::Int; y = x) = x * y

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -29,6 +29,7 @@ k_3(x, y::T, z::U) where {T, U} = x + y + z
 k_4(::String, ::Int = 0) = nothing
 k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = x
 k_6(x::Vector{T}) where T <: Number = x
+k_7(x::Union{T,Nothing}, y::T = zero(T)) where {T <: Number} = x
 
 mutable struct T
     a

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -27,7 +27,7 @@ k_1(x::String, y::Int = 0, z::T = zero(T)) where T <: Number = x
 k_2(x::String, y::U = 0, z::T = zero(T)) where T <: Number where U <: Complex = x
 k_3(x, y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
 k_4(::String, ::Int = 0) = nothing
-
+k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = nothing
 
 mutable struct T
     a

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -22,6 +22,11 @@ i_4(x; y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
 j_1(x, y) = x * y # two arguments, no keyword arguments
 j_1(x; y = x) = x * y # one argument, one keyword argument
 
+k_1(x::String, y::Int = 0, z::T = zero(T)) where T <: Number = x
+k_2(x::String, y::U = 0, z::T = zero(T)) where T <: Number where U <: Complex = x
+k_3(x, y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
+
+
 mutable struct T
     a
     b

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -23,9 +23,9 @@ i_4(x; y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
 j_1(x, y) = x * y # two arguments, no keyword arguments
 j_1(x; y = x) = x * y # one argument, one keyword argument
 
-k_1(x::String, y::Int = 0, z::T = zero(T)) where T <: Number = x
-k_2(x::String, y::U = 0, z::T = zero(T)) where T <: Number where U <: Complex = x
-k_3(x, y::T = zero(T), z::U = zero(U)) where {T, U} = x + y + z
+k_1(x::String, y::Int = 0, z::T = zero(Number)) where T <: Number = x
+k_2(x::String, y::U, z::T) where T <: Number where U <: Complex = x
+k_3(x, y::T, z::U) where {T, U} = x + y + z
 k_4(::String, ::Int = 0) = nothing
 k_5(::Type{T}, x::String, func::Union{Nothing, Function} = nothing) where T <: Number = x
 k_6(x::Vector{T}) where T <: Number = x

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -32,6 +32,7 @@ k_6(x::Vector{T}) where T <: Number = x
 k_7(x::Union{T,Nothing}, y::T = zero(T)) where {T <: Number} = x
 k_8(x) = x
 k_9(x::T where T<:Any) = x
+k_10(x::T) where T = x
 
 mutable struct T
     a

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -233,8 +233,8 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             @test occursin("\nk_1(x::String) -> String\n", str)
-            @test occursin("\nk_1(x::String, y::T) where T<:Number -> String\n", str)
-            @test occursin("\nk_1(x::String, y::T, z::T) where T<:Number -> String\n", str)
+            @test occursin("\nk_1(x::String, y::T<:Number) -> String\n", str)
+            @test occursin("\nk_1(x::String, y::T<:Number, z::T<:Number) -> String\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -246,7 +246,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("k_2(x::String, y::U, z::T) where T<:Number where U<:Complex -> String", str)
+            @test occursin("k_2(x::String, y::U<:Complex, z::T<:Number) -> String", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -257,7 +257,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\nk_3(x::Any, y::T, z::U) where U where T -> Any\n", str)
+            @test occursin("\nk_3(x::Any, y::T, z::U) -> Any\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -308,6 +308,20 @@ end
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
                 @test occursin("\nk_6(x::Array{T<:Number,1}) -> Array{T<:Number,1}\n", str)
+            end
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_7),
+                :typesig => Union{Tuple{Union{T, Nothing}}, Tuple{Union{T, Nothing}, T}, Tuple{T}} where T <: Number,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_7(x::Union{Nothing, T<:Number}) -> Union{Nothing, Number}\n", str)
+                @test occursin("\nk_7(x::Union{Nothing, T<:Number}, y::T<:Number) -> Union{Nothing, T<:Number}\n", str)
             end
             @test occursin("\n```\n", str)
         end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -259,6 +259,22 @@ end
                 @test occursin("\nk_3(x::Int32) -> Any\n", str)
             end
             @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_4),
+                :typesig => Union{Tuple{String}, Tuple{String, Int}},
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("\nk_4(::String)\n", str)
+            if typeof(1) === Int64
+                @test occursin("\nk_4(::String, ::Int64)\n", str)
+            else
+                @test occursin("\nk_4(::String, ::Int32)\n", str)
+            end
+            @test occursin("\n```\n", str)
         end
 
         @testset "function names" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -244,31 +244,25 @@ end
 
             doc.data = Dict(
                 :binding => Docs.Binding(M, :k_2),
-                :typesig => (Union{Tuple{String}, Tuple{String, U}, Tuple{String, U, T}, Tuple{T}, Tuple{U}} where T <: Number) where U <: Complex,
+                :typesig => (Union{Tuple{String, U, T}, Tuple{T}, Tuple{U}} where T <: Number) where U <: Complex,
                 :module => M,
             )
 
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("k_2(x::String) -> String", str)
-            @test occursin("k_2(x::String, y::U) where U<:Complex -> String", str)
             @test occursin("k_2(x::String, y::U, z::T) where T<:Number where U<:Complex -> String", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
                 :binding => Docs.Binding(M, :k_3),
-                :typesig => Union{Tuple{Int}, Tuple{Int, T}, Tuple{Int, T, U}, Tuple{U}, Tuple{T}} where U <: Any where T <: Any,
+                :typesig => (Union{Tuple{Any, T, U}, Tuple{U}, Tuple{T}} where U <: Any) where T <: Any,
                 :module => M,
             )
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if typeof(1) === Int64
-                @test occursin("\nk_3(x::Int64) -> Any\n", str)
-            else
-                @test occursin("\nk_3(x::Int32) -> Any\n", str)
-            end
+            @test occursin("\nk_3(x::Any, y::T, z::U) where U where T -> Any\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -174,7 +174,7 @@ end
             DSE.format(SIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\nh_4(x, _, z)\n", str)
+            @test occursin("\nh_4(x, , z)\n", str)
             @test occursin("\n```\n", str)
         end
 
@@ -304,8 +304,8 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
-                @test occursin("\nk_5(_::Type{T<:Number}, x::String)\n", str)
-                @test occursin("\nk_5(_::Type{T<:Number}, x::String, func::Union{Nothing, Function})\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String)\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function})\n", str)
             end
             @test occursin("\n```\n", str)
         end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -293,6 +293,21 @@ end
                 @test occursin("\nk_4", str)
             end
             @test occursin("\n```\n", str)
+
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_5),
+                :typesig => Union{Tuple{Type{T}, String}, Tuple{Type{T}, String, Union{Nothing, Function}}, Tuple{T}} where T <: Number,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_5(_::Type{T<:Number}, x::String)\n", str)
+                @test occursin("\nk_5(_::Type{T<:Number}, x::String, func::Union{Nothing, Function})\n", str)
+            end
+            @test occursin("\n```\n", str)
         end
 
         @testset "function names" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -324,6 +324,32 @@ end
                 @test occursin("\nk_7(x::Union{Nothing, T<:Number}, y::T<:Number) -> Union{Nothing, T<:Number}\n", str)
             end
             @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_8),
+                :typesig => Union{Tuple{Any}},
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_8(x::Any) -> Any\n", str)
+            end
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_9),
+                :typesig => Union{Tuple{T where T}},
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_9(x::Any) -> Any\n", str)
+            end
+            @test occursin("\n```\n", str)
         end
 
         @testset "function names" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -226,20 +226,15 @@ end
 
             doc.data = Dict(
                 :binding => Docs.Binding(M, :k_1),
-                :typesig => Union{Tuple{String}, Tuple{String, Int}, Tuple{String, Int, T}, Tuple{T}} where T <: Number,
+                :typesig => Union{Tuple{String}, Tuple{String, T}, Tuple{String, T, T}, Tuple{T}} where T <: Number,
                 :module => M,
             )
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             @test occursin("\nk_1(x::String) -> String\n", str)
-            if typeof(1) === Int64
-                @test occursin("k_1(x::String, y::Int64) -> String", str)
-                @test occursin("k_1(x::String, y::Int64, z::T) where T<:Number -> String", str)
-            else
-                @test occursin("k_1(x::String, y::Int32) -> String", str)
-                @test occursin("k_1(x::String, y::Int32, z::T) where T<:Number -> String", str)
-            end
+            @test occursin("\nk_1(x::String, y::T) where T<:Number -> String\n", str)
+            @test occursin("\nk_1(x::String, y::T, z::T) where T<:Number -> String\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -292,9 +292,16 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-            @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
-            @test occursin("\n```\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
+                @test occursin("\n```\n", str)
+            else
+                # TODO: remove this test when julia 1.0.0 support is dropped.
+                # older versions of julia seem to return this
+                # str = "\n```julia\nk_5(#temp#::Type{T<:Number}, x::String) -> String\nk_5(#temp#::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n\n```\n\n"
+                @test occursin("\nk_5", str)
+            end
 
             doc.data = Dict(
                 :binding => Docs.Binding(M, :k_6),

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -268,11 +268,18 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\nk_4(::String)\n", str)
-            if typeof(1) === Int64
-                @test occursin("\nk_4(::String, ::Int64)\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_4(::String)\n", str)
+                if typeof(1) === Int64
+                    @test occursin("\nk_4(::String, ::Int64)\n", str)
+                else
+                    @test occursin("\nk_4(::String, ::Int32)\n", str)
+                end
             else
-                @test occursin("\nk_4(::String, ::Int32)\n", str)
+                # TODO: remove this test when julia 1.0.0 support is dropped.
+                # older versions of julia seem to return this
+                # str = "\n```julia\nk_4(#temp#::String)\nk_4(#temp#::String, #temp#::Int64)\n\n```\n\n"
+                @test occursin("\nk_4", str)
             end
             @test occursin("\n```\n", str)
         end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -224,10 +224,10 @@ end
             @test occursin("\nk_1(x::String) -> String\n", str)
             if typeof(1) === Int64
                 @test occursin("k_1(x::String, y::Int64) -> String", str)
-                @test occursin("k_1(x::String, y::Int64, z::T<:Number) -> String", str)
+                @test occursin("k_1(x::String, y::Int64, z::T) where T<:Number -> String", str)
             else
                 @test occursin("k_1(x::String, y::Int32) -> String", str)
-                @test occursin("k_1(x::String, y::Int32, z::T<:Number) -> String", str)
+                @test occursin("k_1(x::String, y::Int32, z::T) where T<:Number -> String", str)
             end
             @test occursin("\n```\n", str)
 
@@ -241,8 +241,8 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             @test occursin("k_2(x::String) -> String", str)
-            @test occursin("k_2(x::String, y::U<:Complex) -> String", str)
-            @test occursin("k_2(x::String, y::U<:Complex, z::T<:Number) -> String", str)
+            @test occursin("k_2(x::String, y::U) where U<:Complex -> String", str)
+            @test occursin("k_2(x::String, y::U, z::T) where T<:Number where U<:Complex -> String", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -350,6 +350,19 @@ end
                 @test occursin("\nk_9(x::Any) -> Any\n", str)
             end
             @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_10),
+                :typesig => Union{Tuple{T}, Tuple{T}} where T,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test_broken occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test_broken occursin("\nk_10(x::T) -> Any\n", str)
+            end
+            @test_broken occursin("\n```\n", str)
         end
 
         @testset "function names" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -165,6 +165,17 @@ end
             @test occursin("\ng(x, y)\n", str)
             @test occursin("\ng(x, y, z; kwargs...)\n", str)
             @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :h_4),
+                :typesig => Union{Tuple{Any, Int, Any}},
+                :module => M,
+            )
+            DSE.format(SIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("\nh_4(x, _, z)\n", str)
+            @test occursin("\n```\n", str)
         end
 
         @testset "method signatures with types" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -212,6 +212,53 @@ end
                 @test occursin("\nh(x::Int32) -> Int32\n", str)
             end
             @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_1),
+                :typesig => Union{Tuple{String}, Tuple{String, Int}, Tuple{String, Int, T}, Tuple{T}} where T <: Number,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("\nk_1(x::String) -> String\n", str)
+            if typeof(1) === Int64
+                @test occursin("k_1(x::String, y::Int64) -> String", str)
+                @test occursin("k_1(x::String, y::Int64, z::T<:Number) -> String", str)
+            else
+                @test occursin("k_1(x::String, y::Int32) -> String", str)
+                @test occursin("k_1(x::String, y::Int32, z::T<:Number) -> String", str)
+            end
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_2),
+                :typesig => (Union{Tuple{String}, Tuple{String, U}, Tuple{String, U, T}, Tuple{T}, Tuple{U}} where T <: Number) where U <: Complex,
+                :module => M,
+            )
+
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("k_2(x::String) -> String", str)
+            @test occursin("k_2(x::String, y::U<:Complex) -> String", str)
+            @test occursin("k_2(x::String, y::U<:Complex, z::T<:Number) -> String", str)
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_3),
+                :typesig => Union{Tuple{Int}, Tuple{Int, T}, Tuple{Int, T, U}, Tuple{U}, Tuple{T}} where U <: Any where T <: Any,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if typeof(1) === Int64
+                @test occursin("\nk_3(x::Int64) -> Any\n", str)
+            else
+                @test occursin("\nk_3(x::Int32) -> Any\n", str)
+            end
+            @test occursin("\n```\n", str)
         end
 
         @testset "function names" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -174,7 +174,7 @@ end
             DSE.format(SIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\nh_4(x, , z)\n", str)
+            @test occursin("\nh_4(x, ?, z)\n", str)
             @test occursin("\n```\n", str)
         end
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -292,10 +292,8 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
-            end
+            @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
+            @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -306,9 +304,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test occursin("\nk_6(x::Array{T<:Number,1}) -> Array{T<:Number,1}\n", str)
-            end
+            @test occursin("\nk_6(x::Array{T<:Number,1}) -> Array{T<:Number,1}\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -319,10 +315,8 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test occursin("\nk_7(x::Union{Nothing, T<:Number}) -> Union{Nothing, Number}\n", str)
-                @test occursin("\nk_7(x::Union{Nothing, T<:Number}, y::T<:Number) -> Union{Nothing, T<:Number}\n", str)
-            end
+            @test occursin("\nk_7(x::Union{Nothing, T<:Number}) -> Union{Nothing, Number}\n", str)
+            @test occursin("\nk_7(x::Union{Nothing, T<:Number}, y::T<:Number) -> Union{Nothing, T<:Number}\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -333,9 +327,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test occursin("\nk_8(x::Any) -> Any\n", str)
-            end
+            @test occursin("\nk_8(x::Any) -> Any\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -346,9 +338,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test occursin("\nk_9(x::Any) -> Any\n", str)
-            end
+            @test occursin("\nk_9(x::Any) -> Any\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -359,9 +349,7 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test_broken occursin("\n```julia\n", str)
-            if VERSION > v"1.3.0"
-                @test_broken occursin("\nk_10(x::T) -> Any\n", str)
-            end
+            @test_broken occursin("\nk_10(x::T) -> Any\n", str)
             @test_broken occursin("\n```\n", str)
         end
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -304,8 +304,21 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
-                @test occursin("\nk_5(::Type{T<:Number}, x::String)\n", str)
-                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function})\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
+            end
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :k_6),
+                :typesig => Union{Tuple{Vector{T}}, Tuple{T}} where T <: Number,
+                :module => M,
+            )
+            DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            if VERSION > v"1.3.0"
+                @test occursin("\nk_6(x::Array{T<:Number,1}) -> Array{T<:Number,1}\n", str)
             end
             @test occursin("\n```\n", str)
         end


### PR DESCRIPTION
Resolves #84. 

- [x] Fixes type signatures for parametric types
- [x] ~Removes `?` in type signature for functions with nameless arguments~