### PR TITLE
Move some docstrings to internals page

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
     pages = Any[
         "Home" => "index.md",
         "Showcase" => "showcase.md",
+        "Internals" => "internals.md",
     ],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,13 +7,16 @@ DocStringExtensions
 ## Index
 
 ```@index
-Modules = [DocStringExtensions]
+Pages = ["index.md"]
 ```
 
 ## Reference
 
 ```@autodocs
 Modules = [DocStringExtensions]
-Order = [:constant, :function, :macro, :type]
+Order = [:constant]
 ```
 
+```@docs
+DocStringExtensions.@template
+```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -1,0 +1,12 @@
+# Internals
+
+These functions, types etc. are internal to DocStringExtensions and **not part of the public API**. They may change or be removed arbitrarily from version to version.
+
+```@index
+Pages = ["internals.md"]
+```
+
+```@autodocs
+Modules = [DocStringExtensions]
+Order = [:function, :type]
+```


### PR DESCRIPTION
The only things that are actually part of the public API are the abbreviations and the `@template` macro, but the autodocs block was capturing all docstrings. All of these are now "demoted" to be internal:

```
DocStringExtensions.Abbreviation
DocStringExtensions.DocStringTemplate
DocStringExtensions.FunctionName
DocStringExtensions.License
DocStringExtensions.MethodList
DocStringExtensions.MethodSignatures
DocStringExtensions.ModuleExports
DocStringExtensions.ModuleImports
DocStringExtensions.Readme
DocStringExtensions.TypeDefinition
DocStringExtensions.TypeFields
DocStringExtensions.TypedMethodSignatures
DocStringExtensions.alltypesigs
DocStringExtensions.arguments
DocStringExtensions.cleanpath
DocStringExtensions.comparemethods
DocStringExtensions.format
DocStringExtensions.getmethods
DocStringExtensions.getmethods!
DocStringExtensions.groupby
DocStringExtensions.groupby!
DocStringExtensions.hook!
DocStringExtensions.hook!
DocStringExtensions.isabstracttype
DocStringExtensions.isbitstype
DocStringExtensions.keywords
DocStringExtensions.methodgroups
DocStringExtensions.parsedocs
DocStringExtensions.printmethod
DocStringExtensions.printmethod
DocStringExtensions.url
```