### PR TITLE
Set version to 0.8.3.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.2"
+version = "0.8.3"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"


### PR DESCRIPTION
This should fix Documenters test on Julia master: https://github.com/JuliaCI/NanosoldierReports/blob/303a819e120eac6b87b3c74c18c024ae0359e457/pkgeval/by_hash/3573793_vs_c4acbf9/logs/Documenter/1.6.0-DEV-4978cd5a4f.log#L672

Edit: And DocStringExtensions.jl itself too: https://github.com/JuliaCI/NanosoldierReports/blob/303a819e120eac6b87b3c74c18c024ae0359e457/pkgeval/by_hash/3573793_vs_c4acbf9/logs/DocStringExtensions/1.6.0-DEV-4978cd5a4f.log#L68