### PR TITLE
Update Julia versions on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ os:
   - osx
 
 julia:
-  - 0.7
-  - 1.0
   - nightly
+  - 1
+  - 1.4
+  - 1.0
+  - 0.7
 
 notifications:
   email: false
@@ -18,7 +20,7 @@ after_success:
 jobs:
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1.5
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.add(PackageSpec(path=pwd()));

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ after_success:
 
 jobs:
   include:
+    - julia: 1.1, 1.2, 1.3, 1.4
+      os: linux
     - stage: "Documentation"
       julia: 1.5
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ os:
 julia:
   - nightly
   - 1
-  - 1.4
   - 1.0
   - 0.7
 
@@ -19,8 +18,16 @@ after_success:
 
 jobs:
   include:
-    - julia: 1.1, 1.2, 1.3, 1.4
+    # Include intermediate Julia versions, but only on Linux
+    - julia: 1.1
       os: linux
+    - julia: 1.2
+      os: linux
+    - julia: 1.3
+      os: linux
+    - julia: 1.4
+      os: linux
+    # Documentation
     - stage: "Documentation"
       julia: 1.5
       os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   matrix:
   - julia_version: 0.7
+  - julia_version: 1.0
   - julia_version: 1
   - julia_version: nightly
 


### PR DESCRIPTION
To make sure that we're actually testing on the latest release etc.

I also added (Linux) builds for 1.{1,2,3,4}. My argument here is that, since DocStringExtensions can get loaded behind the scenes in packages, we should be a bit more careful and make sure it is actually working on all possible Julia versions (up to a minor version anyhow).