### PR TITLE
Move test deps out of `[deps]`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,14 @@ version = "0.8.4"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[compat]
+julia = "1"
+
+[extras]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-julia = "0.7, 1"
+[targets]
+test = ["Markdown", "Pkg", "Test"]

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -75,6 +75,10 @@ $(IMPORTS)
 """
 module DocStringExtensions
 
+# Imports.
+
+import LibGit2
+
 # Exports.
 
 export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -394,8 +394,6 @@ on TravisCI as well.
 """
 url(m::Method) = url(m.module, string(m.file), m.line)
 
-import LibGit2
-
 function url(mod::Module, file::AbstractString, line::Integer)
     file = Sys.iswindows() ? replace(file, '\\' => '/') : file
     if Base.inbase(mod) && !isabspath(file)


### PR DESCRIPTION
I assume it was probably an artifact of converting to a `Project.toml`. Doesn't need `Pkg`, `Test`, or `Markdown` for the actual dependencies of the package. Drops `0.7` support, that's old enough that I don't feel it needs further support. Also moves the `LibGit2` import to an easier to find location at the top of the package. 