### PR TITLE
Remove is(abstract|bits)type functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.4"
+version = "0.8.5"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -512,7 +512,7 @@ function print_abstract_type(buf, object)
 end
 
 function print_mutable_struct_or_struct(buf, object)
-    object.mutable && print(buf, "mutable ")
+    ismutabletype(object) && print(buf, "mutable ")
     print(buf, "struct ", object.name.name)
     print_params(buf, object)
     print_supertype(buf, object)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -89,6 +89,7 @@ function getmethods!(results, f, sig)
     end
     return results
 end
+
 """
 $(:SIGNATURES)
 
@@ -98,22 +99,6 @@ This is similar to `methods(f, sig)`, but handles type signatures found in `DocS
 more consistently that `methods`.
 """
 getmethods(f, sig) = unique(getmethods!(Method[], f, sig))
-
-
-"""
-$(:SIGNATURES)
-
-Is the type `t` a `bitstype`?
-"""
-isbitstype(@nospecialize(t)) = isconcretetype(t) && sizeof(t) > 0 && isbits(t)
-
-"""
-$(:SIGNATURES)
-
-Is the type `t` an `abstract` type?
-"""
-isabstracttype(@nospecialize(t)) = isa(t, DataType) && getfield(t, :abstract)
-
 
 """
 $(:SIGNATURES)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -461,3 +461,13 @@ function url(mod::Module, file::AbstractString, line::Integer)
         end
     end
 end
+
+# This is compat to make sure that we have ismutabletype available pre-1.7.
+# Implementation borrowed from JuliaLang/julia (MIT license).
+# https://github.com/JuliaLang/julia/pull/39037
+if !isdefined(Base, :ismutabletype)
+    function ismutabletype(@nospecialize(t::Type))
+        t = Base.unwrap_unionall(t)
+        return isa(t, DataType) && t.mutable
+    end
+end


### PR DESCRIPTION
It looks like ~https://github.com/JuliaLang/julia/pull/41018~ https://github.com/JuliaLang/julia/pull/40741 removed the `.abstract` field from `DataType`, so DocStringExtensions is currently broken on nightly because of that. But I think the local `isabstracttype` and `isbitstype` definitions are some pre-1.0 leftovers -- functions with the same name are available in Base -- so it should be safe to just remove them.

`ismutabletype` was added in 1.7 (https://github.com/JuliaLang/julia/pull/39037), so we need a local version of it if it is not defined in `Base`.