### PR TITLE
Adding function_signatures_add, a function that adds function signatures to an entire codebase at once.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
 [deps]
+Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
 [deps]
-Infiltrator = "5903a43b-9cc3-4c30-8d17-598619ec4e9b"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [compat]

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -77,17 +77,18 @@ module DocStringExtensions
 
 import LibGit2
 
-# Exports.
-
-export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS
-export SIGNATURES, TYPEDSIGNATURES, TYPEDEF, DOCSTRING, FUNCTIONNAME
-export README, LICENSE
-
 # Includes.
 
 include("utilities.jl")
 include("abbreviations.jl")
 include("templates.jl")
+include("function_signatures_add.jl")
+
+# Exports.
+
+export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS
+export SIGNATURES, TYPEDSIGNATURES, TYPEDEF, DOCSTRING, FUNCTIONNAME
+export README, LICENSE, function_signatures_add
 
 #
 # Bootstrap abbreviations.

--- a/src/function_signatures_add.jl
+++ b/src/function_signatures_add.jl
@@ -101,5 +101,5 @@ function function_signatures_add(path::AbstractString;
 
 end
 
-# function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false)
-function_signatures_add("/home/andromodon/tmp/genie/test.jl", confirmFirst=false)
+function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false)
+# function_signatures_add("/home/andromodon/tmp/genie/test.jl", confirmFirst=false)

--- a/src/function_signatures_add.jl
+++ b/src/function_signatures_add.jl
@@ -39,7 +39,7 @@ If !confirmFirst, then we just assume it's ok.
 """
 function files_ok_with_user(files,confirmFirst::Bool)
     if confirmFirst
-        print("These are the files I am about to edit:\n\n")
+        print("These are the files I am about to edit.  Please make sure they're under version control before continuing:\n\n")
         foreach(x->println("\t"*x), files)
         print("\n")
 
@@ -63,7 +63,7 @@ end
 function_signatures_add(path::AbstractString,
                         signatureString::AbstractString="\$TYPEDSIGNATURES",
                         confirmFirst::Bool=true,
-                        replaceExistingSignatures::Bool=true,
+                        removeExistingSignatureFirst::Bool=true,
                         followSymlinks=::Bool=false)::Nothing
 
 This function is used to add function signatures to an entire code-base with one command, or to standarsize
@@ -74,8 +74,8 @@ If confirmFirst is true(default), it will display the list of files it intends t
 confirmation first.
 
 After that, it reads the files, searches for strings ending on the line before a line starting with "function",
-removes any existing function signatures (if replaceExistingSignatures, which is default), and makes sure 
-the beginning of the string starts with signatureString (Defaults to TYPEDSIGNATURES), two newlines, 
+removes any existing function signatures (if removeExistingSignatureFirst, which is default), and makes sure 
+the beginning of the string starts with signatureString (Defaults to "\$TYPEDSIGNATURES\n\n"), 
 and then whatever printable text was there before that was not a function signature.
 
 followSymlinks (default: false) says whether to follow symbolic links when recursively traversing directories.
@@ -86,7 +86,7 @@ If you're using git, the changes can be reviewed before comitting, to help build
 function function_signatures_add(path::AbstractString;
                                  signatureString::AbstractString="\$TYPEDSIGNATURES",
                                  confirmFirst::Bool=true,
-                                 replaceExistingSignatures::Bool=true,
+                                 removeExistingSignatureFirst::Bool=true,
                                  followSymlinks::Bool=false)
     
     allFiles=file_list_get(path,followSymlinks)
@@ -97,9 +97,12 @@ function function_signatures_add(path::AbstractString;
     end
 
     #Actually add them:
-    foreach(x->function_signatures_add_to_file(x,signatureString,replaceExistingSignatures), onlyJlFiles)
+    foreach(x->function_signatures_add_to_file(x,signatureString,removeExistingSignatureFirst), onlyJlFiles)
 
 end
 
-function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false)
 # function_signatures_add("/home/andromodon/tmp/genie/test.jl", confirmFirst=false)
+# function_signatures_add("/home/andromodon/tmp/genie/docStringsGalore.jl", confirmFirst=false)
+# function_signatures_add("/home/andromodon/tmp/genie/mistakes.jl", confirmFirst=false, removeExistingSignatureFirst=true)
+# function_signatures_add("/home/andromodon/tmp/genie/try.jl", confirmFirst=false, removeExistingSignatureFirst=true)
+function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false, removeExistingSignatureFirst=true)

--- a/src/function_signatures_add.jl
+++ b/src/function_signatures_add.jl
@@ -100,9 +100,3 @@ function function_signatures_add(path::AbstractString;
     foreach(x->function_signatures_add_to_file(x,signatureString,removeExistingSignatureFirst), onlyJlFiles)
 
 end
-
-# function_signatures_add("/home/andromodon/tmp/genie/test.jl", confirmFirst=false)
-# function_signatures_add("/home/andromodon/tmp/genie/docStringsGalore.jl", confirmFirst=false)
-# function_signatures_add("/home/andromodon/tmp/genie/mistakes.jl", confirmFirst=false, removeExistingSignatureFirst=true)
-# function_signatures_add("/home/andromodon/tmp/genie/try.jl", confirmFirst=false, removeExistingSignatureFirst=true)
-function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false, removeExistingSignatureFirst=true)

--- a/src/function_signatures_add.jl
+++ b/src/function_signatures_add.jl
@@ -1,0 +1,105 @@
+#!/opt/bin/julia --project="."
+
+using Infiltrator
+
+include("./function_signatures_add_to_file.jl")
+
+"""
+Converts a path to a file or directory to a list of all of the files under it.
+
+followSymlinks (defulat false) says whether to follow symbolic links when recursively traversing directories.
+"""
+function file_list_get(path::AbstractString,  followSymlinks::Bool=false)::Vector{String}
+    
+    if !ispath(path)
+        throw(ArgumentError("'$path' could not be found."))
+    end
+
+    if isfile(path) || (islink(path) && followSymlinks)
+        return [path]
+    elseif !isdir(path)
+        throw(ArgumentError("path='$path' is not a directory or a file. " 
+                            *"If it's a symlink, make sure to use followSymlinks=true."))
+    end
+
+    #Ok, at this point, path should be a directory.
+
+    walkdir(path, follow_symlinks=followSymlinks) |> #Produces a collection of (root, dirs, files)
+        y-> map(x-> [ joinpath(x[1], file) for file in x[3]],y) |> #Converts each tuple to a list of full paths to the files.
+        x->vcat(x...) #Concatenates the list of lists into a single list
+end
+
+
+"""
+files_ok_with_user(files,confirmFirst::bool)
+
+If confirmFirst is true, then this checks with the user to see if the list of files we're about to edit is ok.
+
+If !confirmFirst, then we just assume it's ok.
+"""
+function files_ok_with_user(files,confirmFirst::Bool)
+    if confirmFirst
+        print("These are the files I am about to edit:\n\n")
+        foreach(x->println("\t"*x), files)
+        print("\n")
+
+        cont=input("Would you like me to continue? y/[n]:")
+
+        if strip(cont)!= "y"
+            println("\nOk, let's get the heck out of here!")
+            return false
+        end
+    end
+
+    return true
+end
+
+function input(prompt::AbstractString)
+    print(prompt)
+    readline()
+end
+
+"""
+function_signatures_add(path::AbstractString,
+                        signatureString::AbstractString="\$TYPEDSIGNATURES",
+                        confirmFirst::Bool=true,
+                        replaceExistingSignatures::Bool=true,
+                        followSymlinks=::Bool=false)::Nothing
+
+This function is used to add function signatures to an entire code-base with one command, or to standarsize
+function signatures if they already exist.
+
+This function edits all of the .jl files at or below path (which can be a directory or a .jl file).
+If confirmFirst is true(default), it will display the list of files it intends to edit and seek user 
+confirmation first.
+
+After that, it reads the files, searches for strings ending on the line before a line starting with "function",
+removes any existing function signatures (if replaceExistingSignatures, which is default), and makes sure 
+the beginning of the string starts with signatureString (Defaults to TYPEDSIGNATURES), two newlines, 
+and then whatever printable text was there before that was not a function signature.
+
+followSymlinks (default: false) says whether to follow symbolic links when recursively traversing directories.
+
+If you're using git, the changes can be reviewed before comitting, to help build confidence.
+
+"""
+function function_signatures_add(path::AbstractString;
+                                 signatureString::AbstractString="\$TYPEDSIGNATURES",
+                                 confirmFirst::Bool=true,
+                                 replaceExistingSignatures::Bool=true,
+                                 followSymlinks::Bool=false)
+    
+    allFiles=file_list_get(path,followSymlinks)
+    onlyJlFiles=filter( x-> match(r"\.jl$", x)!=nothing , allFiles)
+
+    if !files_ok_with_user(onlyJlFiles,confirmFirst)
+        return
+    end
+
+    #Actually add them:
+    foreach(x->function_signatures_add_to_file(x,signatureString,replaceExistingSignatures), onlyJlFiles)
+
+end
+
+# function_signatures_add("/home/andromodon/tmp/genie/genie.jl", confirmFirst=false)
+function_signatures_add("/home/andromodon/tmp/genie/test.jl", confirmFirst=false)

--- a/src/function_signatures_add.jl
+++ b/src/function_signatures_add.jl
@@ -1,7 +1,5 @@
 #!/opt/bin/julia --project="."
 
-using Infiltrator
-
 include("./function_signatures_add_to_file.jl")
 
 """

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -1,35 +1,47 @@
+using Infiltrator
 
-function file_contents_as_string(filePath)
-    open(filePath) do fileHandle
-        return read(fileHandle, String)
-    end
-end
-
-signatureStringsAcceptable=("\$TYPEDSIGNATURES","\$SIGNATURES", 
+sigStringStrippedAcceptable=("\$TYPEDSIGNATURES","\$SIGNATURES", 
                             "\$(TYPEDSIGNATURES)", "\$(SIGNATURES)")
 
+
+function components_display(components)
+    display(collect(enumerate(components)))
+    print("\n----------------------\n")
+end
+
 """
+function_signatures_add_to_file(filePath, signatureString, removeExistingSignatureFirst)
+
 Edits the file at filePath to make sure every function in it has a function signature in it's docstring.
 
-If replaceExistingSignatures is true, then it also removes existing function signatures and replaces those.
+If removeExistingSignatureFirst is true, then it also removes existing function signatures and replaces those.
 
-signatureString should be one of $signatureStringsAcceptable
+signatureString should be one of $sigStringStrippedAcceptable
 """
-function function_signatures_add_to_file(filePath, signatureString, replaceExistingSignatures)
+function function_signatures_add_to_file(filePath, signatureString, removeExistingSignatureFirst)
+
     if signatureString ∉ ("\$TYPEDSIGNATURES","\$SIGNATURES", "\$(TYPEDSIGNATURES)", "\$(SIGNATURES)")
-        throw(ArgumentError("'$signatureString' is not one of these expected values: $signatureStringsAcceptable"))
+        throw(ArgumentError("'$signatureString' is not one of these: $sigStringStrippedAcceptable"))
     end
+
+    #Says if we'll output debugging info when we run:
+    printStuff=false
 
     #Read the file:
     fileAsString=file_contents_as_string(filePath)
 
-    #Inspired by https://stackoverflow.com/questions/49906179/regex-to-match-string-syntax-in-code
+    #Our regexes that we'll put together into one big one (so the groups numbers refer to the whole thing not the parts)
     everythingBefore=r"(.*?)"s
-    docStringGroups=r"(\"\"\"|\")((?:(?!\2)(?:\\.|[^\\]))*)(\2)"s
+    #Inspired by https://stackoverflow.com/questions/49906179/regex-to-match-string-syntax-in-code
+    #Groups:  begQuote, docString, endQuote
+    docStringGroups=r"(?:(\"\"\"|\")((?:(?!\2)(?:\\.|[^\\]))*)(\2))?"s
     whitespaceGroup=r"([ \t]*\n)"
-    functionGroup=r"([ \t]*function .*?\n)"
+    #matches:whiteSpaceBeforeFunction functionWordAndWhitespaceAfter moduleAndFunctionName restOfLine
+    functionGroup=r"([ \t]*)(function[ \t]+)([^\(\s]+)(.*?\n)"
 
     regexToMatch=everythingBefore   * docStringGroups * whitespaceGroup * functionGroup
+
+    printStuff && ( println(regexToMatch); println(""))
 
     #Get all of the matches, one per function that has a docstring:
     docStringsWhitespaceAndFunctions=eachmatch(regexToMatch, fileAsString)
@@ -37,33 +49,132 @@ function function_signatures_add_to_file(filePath, signatureString, replaceExist
     #This is just to keep this at this scope:
     endOfLastGroup=-1
 
-    #This is an array we'll append to and then concatenate to make sure we don't miss anything
-    # in the regexes:
-    fileParts=[]
+    #This is an array we'll append to and then concatenate to make sure the regexes don't miss anything.
+    inFileParts=[]
+
+    #This is where we'll accumulate the output:
+    outFileParts=[]
 
     #Go through them, one by one:
     for regexMatch in docStringsWhitespaceAndFunctions
         
-        components=regexMatch.captures 
+        inComponents=regexMatch.captures 
         
         #Break it up:
-        (everythingBefore, begQuote, docString, endQuote, whitespace, func)=components
+        (everythingBefore, begQuote, docString, endQuote, whitespace,
+             whiteSpaceBeforeFunction, func, moduleAndFunctionName, funcRestOfLine)=inComponents
+        
+        #Debugging info:
+        printStuff && components_display(inComponents)
 
-        # print(join(components, "|"))
-        # print("\n----------------------\n")
-
+        #Get info we'll need about where we left off so we can calculate restOfFile later:
         startOfLastGroup=regexMatch.offsets[end]
-        endOfLastGroup=startOfLastGroup+length(func)
+        endOfLastGroup=startOfLastGroup+length(funcRestOfLine)
 
-        push!(fileParts,join(components, ""))
+        #Calculate our new docString:
+        outDocString=doc_string_modify(docString, moduleAndFunctionName, signatureString, removeExistingSignatureFirst)
+
+        #Make outComponents from inComponents by replacing the docString and wrapping in tripple quotes always:
+        outComponents=deepcopy(inComponents)
+        outComponents[2]=indent_with_string(whiteSpaceBeforeFunction, "\"\"\"")
+        outComponents[3]=indent_with_string(whiteSpaceBeforeFunction, outDocString)
+        outComponents[4]="\"\"\""
+
+        #If we're inserting our own docString, add an additional \n before it to make the spacing right:
+        if docString == nothing
+            outComponents[2]="\n"*outComponents[2]
+        end
+
+        #Add what we've parsed to inFileParts as a double-check, and also the output stuff outFileParts:
+        push!(inFileParts,join(inComponents, ""))
+        push!(outFileParts, join(outComponents, ""))
     end
 
     #The remainder of our file:
     restOfFile=fileAsString[endOfLastGroup:end]
-    # print(restOfFile)
-    push!(fileParts, restOfFile)
+    
+    #Complete both inFileParts and outFileParts by adding the rest of the file:
+    push!(inFileParts, restOfFile)
+    push!(outFileParts, restOfFile)
 
-    fileReassembled=join(fileParts,"")
+    inFileReassembled=join(inFileParts,"")
+    outFileStr=join(outFileParts,"")
+    
+    printStuff && print(restOfFile)
 
-    @assert fileReassembled==fileAsString "Oh, crap, some part of the document escaped my regex!!"
+    # @assert inFileReassembled==fileAsString "Oh, crap, some part of the document escaped my regex!!"
+
+    #Write the file to disk:
+    write(filePath * ".new", outFileStr)
+end
+
+function file_contents_as_string(filePath)
+    open(filePath) do fileHandle
+        return read(fileHandle, String)
+    end
+end
+
+"Adds stringToAdd at the beginning of each line in str"
+function indent_with_string(stringToAdd, str)
+    str |> x->split(x,"\n") |> y-> map(x->stringToAdd * x, y) |> x-> join(x,"\n")
+end
+
+"""
+Takes something like "Abc.Def.funcName" or "funcName" and returns just "funcName"
+"""
+function get_function_name(moduleAndFunctionName)
+    replace(moduleAndFunctionName, r".*\." => "")
+end
+
+"""
+Takes the doc_string and either adds a function signature or replaces the existing one, depending on removeExistingSignatureFirst.  
+"""
+function doc_string_modify(docString, moduleAndFunctionName, signatureString, removeExistingSignatureFirst)
+    
+    printStuffHere=true
+
+    #Make sure we actually have a string, even if the docString thing didn't match:
+    if docString==nothing
+        docString=""
+    end
+
+    #Strip out any module path stuff from the function name, since it may or may not be in the signture:
+    functionName=get_function_name(moduleAndFunctionName)
+
+    #I use ra to keep from having to escape a bunch of stuff, and I use Regex instead of r"asdf" so I can interporate
+    # the functionName in it.
+    #Matching parenthesis inspired by https://stackoverflow.com/questions/546433/regular-expression-to-match-balanced-parentheses
+    docStrRe=Regex(raw"(^\s*)([^s]*?" * "$functionName" * raw")(\((?:[^)(]+|(?-1))*+\))?([^\n]*\n\s*)?(.*?)(\s*)$","s")
+    
+    printStuffHere && ( println(docStrRe); println(""))
+
+    docStrMatch=match(docStrRe, docString)
+    @assert(docStrMatch!=nothing, "docStrRe should always match and it didn't!  String was : \"\"\"$docString\"\"\"")
+
+    (whitespaceBeforeSignature, f1,f2,f3, restOfDocString, endingWhitespace)=docStrMatch.captures
+
+    functionSignatureAndWhitespaceAfter=join((f1,f2,f3), "")
+
+    printStuffHere && components_display(docStrMatch.captures)
+
+    #If we're supposed to keep existing signatures and there's something to keep:
+    if !removeExistingSignatureFirst && functionSignatureAndWhitespaceAfter != nothing
+        #Use what's there:
+        outSignatureString=functionSignatureAndWhitespaceAfter
+    else
+        #Insert our own:
+        outSignatureString=signatureString
+
+        #Add two \n\n between if there is stuff to separate.  If it's just the signatureString, then don't add the extra newlines:        
+        if length(restOfDocString)!=0
+            outSignatureString=outSignatureString* "\n\n"
+        end
+    end
+
+    docStringOut=outSignatureString * restOfDocString
+        
+    #Wrap in \n so it feels at home in """:
+    docStringOut="\n" * docStringOut * "\n"
+
+    return docStringOut
 end

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -131,7 +131,7 @@ Takes the doc_string and either adds a function signature or replaces the existi
 """
 function doc_string_modify(docString, moduleAndFunctionName, signatureString, removeExistingSignatureFirst)
     
-    printStuffHere=true
+    printStuffHere=false
 
     #Make sure we actually have a string, even if the docString thing didn't match:
     if docString==nothing
@@ -144,7 +144,7 @@ function doc_string_modify(docString, moduleAndFunctionName, signatureString, re
     #I use ra to keep from having to escape a bunch of stuff, and I use Regex instead of r"asdf" so I can interporate
     # the functionName in it.
     #Matching parenthesis inspired by https://stackoverflow.com/questions/546433/regular-expression-to-match-balanced-parentheses
-    docStrRe=Regex(raw"(^\s*)([^s]*?" * "$functionName" * raw")(\((?:[^)(]+|(?-1))*+\))?([^\n]*\n\s*)?(.*?)(\s*)$","s")
+    docStrRe=Regex(raw"(^\s*)([^s]*?" * "$functionName" * raw")?(\((?:[^)(]+|(?-1))*+\))?([^\n]*\n\s*)?(.*?)(\s*)$","s")
     
     printStuffHere && ( println(docStrRe); println(""))
 

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -46,8 +46,8 @@ function function_signatures_add_to_file(filePath, signatureString, removeExisti
     #Get all of the matches, one per function that has a docstring:
     docStringsWhitespaceAndFunctions=eachmatch(regexToMatch, fileAsString)
     
-    #This is just to keep this at this scope:
-    endOfLastGroup=-1
+    #This is to keep this at this scope and to initialize if there isn't a match:
+    endOfLastGroup=1
 
     #This is an array we'll append to and then concatenate to make sure the regexes don't miss anything.
     inFileParts=[]

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -1,0 +1,42 @@
+
+function file_contents_as_string(filePath)
+    open(filePath) do fileHandle
+        return read(fileHandle, String)
+    end
+end
+
+signatureStringsAcceptable=("\$TYPEDSIGNATURES","\$SIGNATURES", 
+                            "\$(TYPEDSIGNATURES)", "\$(SIGNATURES)")
+
+"""
+Edits the file at filePath to make sure every function in it has a function signature in it's docstring.
+
+If replaceExistingSignatures is true, then it also removes existing function signatures and replaces those.
+
+signatureString should be one of $signatureStringsAcceptable
+"""
+function function_signatures_add_to_file(filePath, signatureString, replaceExistingSignatures)
+    if signatureString ∉ ("\$TYPEDSIGNATURES","\$SIGNATURES", "\$(TYPEDSIGNATURES)", "\$(SIGNATURES)")
+        throw(ArgumentError("'$signatureString' is not one of these expected values: $signatureStringsAcceptable"))
+    end
+
+    #Read the file:
+    fileAsString=file_contents_as_string(filePath)
+
+    docStringGroup=r"(\"[^\"]*[^\\\"]\"|\"\"\".*?\"\"\")"s
+    whitespaceGroup=r"([ \t]*\n)"
+    functionGroup=r"([ \t]*function .*\n)"
+
+    regexToMatch=docStringGroup * whitespaceGroup * functionGroup
+
+    docStringsWhitespaceAndFunctions=eachmatch(regexToMatch, fileAsString)
+    
+    for regexMatch in docStringsWhitespaceAndFunctions
+        
+        (docString, whitespace, func)=regexMatch.captures 
+        
+        println("$docString|$whitespace|$func")
+        println("----------------------")
+
+    end
+end

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -23,20 +23,47 @@ function function_signatures_add_to_file(filePath, signatureString, replaceExist
     #Read the file:
     fileAsString=file_contents_as_string(filePath)
 
-    docStringGroup=r"(\"[^\"]*[^\\\"]\"|\"\"\".*?\"\"\")"s
+    #Inspired by https://stackoverflow.com/questions/49906179/regex-to-match-string-syntax-in-code
+    everythingBefore=r"(.*?)"s
+    docStringGroups=r"(\"\"\"|\")((?:(?!\2)(?:\\.|[^\\]))*)(\2)"s
     whitespaceGroup=r"([ \t]*\n)"
-    functionGroup=r"([ \t]*function .*\n)"
+    functionGroup=r"([ \t]*function .*?\n)"
 
-    regexToMatch=docStringGroup * whitespaceGroup * functionGroup
+    regexToMatch=everythingBefore   * docStringGroups * whitespaceGroup * functionGroup
 
+    #Get all of the matches, one per function that has a docstring:
     docStringsWhitespaceAndFunctions=eachmatch(regexToMatch, fileAsString)
     
+    #This is just to keep this at this scope:
+    endOfLastGroup=-1
+
+    #This is an array we'll append to and then concatenate to make sure we don't miss anything
+    # in the regexes:
+    fileParts=[]
+
+    #Go through them, one by one:
     for regexMatch in docStringsWhitespaceAndFunctions
         
-        (docString, whitespace, func)=regexMatch.captures 
+        components=regexMatch.captures 
         
-        println("$docString|$whitespace|$func")
-        println("----------------------")
+        #Break it up:
+        (everythingBefore, begQuote, docString, endQuote, whitespace, func)=components
 
+        # print(join(components, "|"))
+        # print("\n----------------------\n")
+
+        startOfLastGroup=regexMatch.offsets[end]
+        endOfLastGroup=startOfLastGroup+length(func)
+
+        push!(fileParts,join(components, ""))
     end
+
+    #The remainder of our file:
+    restOfFile=fileAsString[endOfLastGroup:end]
+    # print(restOfFile)
+    push!(fileParts, restOfFile)
+
+    fileReassembled=join(fileParts,"")
+
+    @assert fileReassembled==fileAsString "Oh, crap, some part of the document escaped my regex!!"
 end

--- a/src/function_signatures_add_to_file.jl
+++ b/src/function_signatures_add_to_file.jl
@@ -105,7 +105,7 @@ function function_signatures_add_to_file(filePath, signatureString, removeExisti
     # @assert inFileReassembled==fileAsString "Oh, crap, some part of the document escaped my regex!!"
 
     #Write the file to disk:
-    write(filePath * ".new", outFileStr)
+    write(filePath, outFileStr)
 end
 
 function file_contents_as_string(filePath)


### PR DESCRIPTION
I wanted a good way to fairly easily update an entire codebase's docstrings with function signatures like $TYPEDSIGNATURES.  This does that, and I think it might help others as well.

It's not meant to be perfect - nothing short of rewriting the julia parser will do that, IMHO, but it hits 98% of the cases just fine and requires an acceptable level of manual checking/cleanup.

The function asks users to only continue if they have the code under source control and can easily inspect and tweak things, so the risk of harm is low.

The same function can be used to convert a single file or a whole directory tree.

I tested this on 10000 lines of open-source code, and it worked perfectly for 98% of the functions defined.  The other 2% was fairly easy to correct.

Known issues:
* strings with function definitions in them mess things up a bit.  This is because the regexes can't easily keep track of if we're inside a string or not.  This is farily unavoidable with the approach I have.  Thankfully, only macro-heavy code should have this, and the majority of code wont'.
* If a function has multiple existing function signatures, only the first one is replaced.  This can be "fixed" by wrapping the right part of my regex in a {} type repeat, but I'm afraid I am out of juice for that last little tweak.  I'll leave it as an exercise to anyone who wants to improve on what I've done here.  

A note to anyone who takes it from here:  https://regex101.com is amazing!

