### PR TITLE
Fix extraction of argnames for generated functions

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -431,9 +431,18 @@ args = arguments(first(methods(f)))
 ```
 """
 function arguments(m::Method)
-    local template = get_method_source(m)
-    if isdefined(template, :slotnames)
-        local args = map(template.slotnames[1:nargs(m)]) do arg
+    local argnames = nothing
+    if isdefined(m, :generator)
+        # Generated function.
+        argnames = m.generator.argnames
+    else
+        local template = get_method_source(m)
+        if isdefined(template, :slotnames)
+            argnames = template.slotnames
+        end
+    end
+    if !isnothing(argnames)
+        local args = map(argnames) do arg
             arg === Symbol("#unused#") ? "_" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -442,7 +442,7 @@ function arguments(m::Method)
         end
     end
     if !isnothing(argnames)
-        local args = map(argnames) do arg
+        local args = map(argnames[1:nargs(m)]) do arg
             arg === Symbol("#unused#") ? "_" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)


### PR DESCRIPTION
Fixes #126. I don't really know where we could integrate a related test to the test suite, I am open to suggestions. At least the MWE linked in the issue now works.