### PR TITLE
Break long docstrings into multiple lines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - uses: julia-actions/julia-runtest@latest
+        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -190,8 +190,8 @@ function printmethod_format(buffer::IOBuffer, binding::String, args::Vector{Stri
     if method_length_over_limit(
             length(binding) +
             1 +
-            sum(length, args; init = 0) +
-            sum(length, kws; init = 0) +
+            sum(length.(args)) +
+            sum(length.(kws)) +
             2*max(0, length(args)-1) +
             2*length(kws) +
             1 +

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -562,7 +562,7 @@ Format the return type to look prettier.
 """
 function format_return_type_string(rt; delim = "  ", break_point=40)
     if startswith(string(rt), "Tuple{") && length(string(rt)) > break_point
-        string(
+        string( #TODO Unions[...} look ugly
             "Tuple{\n$delim", 
             join([string(x) for x in rt.types],",\n$delim"),
             "\n}",

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -286,7 +286,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     local args = arguments(method)
     local kws = keywords(func, method)
     local where_syntax = []
-    
+
     # find inner tuple type
     function f(t)
         # t is always either a UnionAll which represents a generic type or a Tuple where each parameter is the argument
@@ -335,10 +335,10 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     break signature up into a nicely formatted multiline method signature.
     =#
     nl_delim, nl = get_format_delimiters(
-        args, 
+        args,
         kws;
-        type_info = join([string(get_type_at_i(typesig, i)) for i in eachindex(args)]), 
-        delim="  ", 
+        type_info = join([string(get_type_at_i(typesig, i)) for i in eachindex(args)]),
+        delim="  ",
         break_point=40
     )
 
@@ -547,12 +547,12 @@ new line character. Otherwise, return an empty string, so that the formatting is
 unaffected.
 """
 function get_format_delimiters(args, kws; delim="  ", break_point=40, type_info = "")
-    estimated_line_width = length(join(string.(args))) + 
+    estimated_line_width = length(join(string.(args))) +
         length(join(string.(kws))) + length(type_info)
-    
+
     nl_delim = estimated_line_width > break_point ? "\n$delim" : ""
     nl = estimated_line_width > break_point ? "\n" : ""
-    
+
     return nl_delim, nl
 end
 
@@ -564,7 +564,7 @@ Format the return type to look prettier.
 function format_return_type_string(rt; delim = "  ", break_point=40)
     if startswith(string(rt), "Tuple{") && length(string(rt)) > break_point
         string(
-            "Tuple{\n$delim", 
+            "Tuple{\n$delim",
             join([string(x) for x in rt.types],",\n$delim"),
             "\n}",
         )

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -563,7 +563,7 @@ Format the return type to look prettier.
 function format_return_type_string(rt; delim = "  ", break_point=40)
     if startswith(string(rt), "Tuple{") && length(string(rt)) > break_point
         string(
-            "Tuple{\n", 
+            "Tuple{\n$delim", 
             join([string(x) for x in rt.types],",\n$delim"),
             "\n}",
         )

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -197,6 +197,8 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     # TODO: print qualified?
     print(buffer, binding.var)
     print(buffer, "(")
+    local args = arguments(method)
+    local kws = keywords(func, method)
 
     #=
     Calculate how long the string of the args and kwargs are. If too long,
@@ -204,8 +206,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
     =#
     nl_delim, nl = get_format_delimiters(args, kws; delim="  ", break_point=40)
 
-    join(buffer, arguments(method), ", $nl_delim")
-    local kws = keywords(func, method)
+    join(buffer, args, ", $nl_delim")
     if !isempty(kws)
         print(buffer, "; $nl_delim")
         join(buffer, kws, ", $nl_delim")
@@ -562,12 +563,12 @@ Format the return type to look prettier.
 """
 function format_return_type_string(rt; delim = "  ", break_point=40)
     if startswith(string(rt), "Tuple{") && length(string(rt)) > break_point
-        string( #TODO Unions[...} look ugly
+        string(
             "Tuple{\n$delim", 
             join([string(x) for x in rt.types],",\n$delim"),
             "\n}",
         )
-    else
+    else #TODO Unions{...} look ugly, but represent one type, so maybe should be on one line
         string(rt)
     end
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -190,8 +190,8 @@ function printmethod_format(buffer::IOBuffer, binding::String, args::Vector{Stri
     if method_length_over_limit(
             length(binding) +
             1 +
-            sum(length.(args)) +
-            sum(length.(kws)) +
+            sum(length, args; init = 0) +
+            sum(length, kws; init = 0) +
             2*max(0, length(args)-1) +
             2*length(kws) +
             1 +
@@ -199,7 +199,7 @@ function printmethod_format(buffer::IOBuffer, binding::String, args::Vector{Stri
 
         sep_delim = "\n"
         paren_delim = "\n"
-        indent = "  "
+        indent = "    "
     end
 
     print(buffer, binding)
@@ -356,7 +356,7 @@ function printmethod(buffer::IOBuffer, binding::Docs.Binding, func, method::Meth
             type = "::$t"
         end
 
-        string(arg)*type*suffix
+        "$arg$type$suffix"
     end
 
     rt = Base.return_types(func, typesig)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -307,7 +307,7 @@ end
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
                 @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-                @test occursin("\nk_5(\n  ::Type{T<:Number},\n  x::String,\n  func::Union{Nothing, Function}\n) -> String\n", str)
+                @test occursin("\nk_5(\n    ::Type{T<:Number},\n    x::String,\n    func::Union{Nothing, Function}\n) -> String\n", str)
                 @test occursin("\n```\n", str)
             else
                 # TODO: remove this test when julia 1.0.0 support is dropped.
@@ -343,11 +343,11 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             if VERSION >= v"1.6" && VERSION < v"1.7"
-                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, Integer}\n", str)
-                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, Integer}\n", str)
+                @test occursin("\nk_7(\n    x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, Integer}\n", str)
+                @test occursin("\nk_7(\n    x::Union{Nothing, T} where T<:Integer,\n    y::Integer\n) -> Union{Nothing, Integer}\n", str)
             else
-                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
-                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
+                @test occursin("\nk_7(\n    x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
+                @test occursin("\nk_7(\n    x::Union{Nothing, T} where T<:Integer,\n    y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             end
             @test occursin("\n```\n", str)
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -307,7 +307,7 @@ end
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
                 @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-                @test occursin("\nk_5(::Type{T<:Number}, x::String, func::Union{Nothing, Function}) -> String\n", str)
+                @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\nk_5(\n  ::Type{T<:Number}, \n  x::String, \n  func::Union{Nothing, Function}\n) -> String\n\n", str)
                 @test occursin("\n```\n", str)
             else
                 # TODO: remove this test when julia 1.0.0 support is dropped.
@@ -347,7 +347,7 @@ end
             else
                 @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, Integer}\n", str)
             end
-            @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer, y::Integer) -> Union{Nothing, T} where T<:Integer\n", str)
+            @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, T} where T<:Integer\nk_7(\n  x::Union{Nothing, T} where T<:Integer, \n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -342,12 +342,13 @@ end
             DSE.format(DSE.TYPEDSIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            if VERSION > v"1.7" || VERSION < v"1.1"
-                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
-            else
+            if VERSION >= v"1.6" && VERSION < v"1.7"
                 @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, Integer}\n", str)
+                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, Integer}\n", str)
+            else
+                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
+                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             end
-            @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -307,7 +307,7 @@ end
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
                 @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-                @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\nk_5(\n  ::Type{T<:Number}, \n  x::String, \n  func::Union{Nothing, Function}\n) -> String\n\n", str)
+                @test occursin("\nk_5(\n  ::Type{T<:Number}, \n  x::String, \n  func::Union{Nothing, Function}\n) -> String\n", str)
                 @test occursin("\n```\n", str)
             else
                 # TODO: remove this test when julia 1.0.0 support is dropped.
@@ -347,7 +347,7 @@ end
             else
                 @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, Integer}\n", str)
             end
-            @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, T} where T<:Integer\nk_7(\n  x::Union{Nothing, T} where T<:Integer, \n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n\n", str)
+            @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer, \n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -190,9 +190,9 @@ end
             f = str -> replace(str, " " => "")
             str = f(str)
             if Sys.iswindows()
-                @test occursin(f("h_1(x::Union{Array{T,4}, Array{T,3}} where T) -> Union{Array{T,4}, Array{T,3}} where T"), str)
+                @test occursin(f("h_1(\nx::Union{Array{T,4}, Array{T,3}} where T\n) -> Union{Array{T,4}, Array{T,3}} where T"), str)
             else
-                @test occursin(f("h_1(x::Union{Array{T,3}, Array{T,4}} where T) -> Union{Array{T,3}, Array{T,4}} where T"), str)
+                @test occursin(f("h_1(\nx::Union{Array{T,3}, Array{T,4}} where T\n) -> Union{Array{T,3}, Array{T,4}} where T"), str)
             end
             @test occursin("\n```\n", str)
 
@@ -307,7 +307,7 @@ end
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.3.0"
                 @test occursin("\nk_5(::Type{T<:Number}, x::String) -> String\n", str)
-                @test occursin("\nk_5(\n  ::Type{T<:Number}, \n  x::String, \n  func::Union{Nothing, Function}\n) -> String\n", str)
+                @test occursin("\nk_5(\n  ::Type{T<:Number},\n  x::String,\n  func::Union{Nothing, Function}\n) -> String\n", str)
                 @test occursin("\n```\n", str)
             else
                 # TODO: remove this test when julia 1.0.0 support is dropped.
@@ -343,11 +343,11 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             if VERSION > v"1.7" || VERSION < v"1.1"
-                @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, T} where T<:Integer\n", str)
+                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             else
-                @test occursin("\nk_7(x::Union{Nothing, T} where T<:Integer) -> Union{Nothing, Integer}\n", str)
+                @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer\n) -> Union{Nothing, Integer}\n", str)
             end
-            @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer, \n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
+            @test occursin("\nk_7(\n  x::Union{Nothing, T} where T<:Integer,\n  y::Integer\n) -> Union{Nothing, T} where T<:Integer\n", str)
             @test occursin("\n```\n", str)
 
             doc.data = Dict(


### PR DESCRIPTION
This PR should address the issues raised in #120. Currently, long docstrings can become unwieldy to view in the repl. For example, in a package I am developing, this is the first part of the docstring for the function `differentiate!`:
```julia
differentiate!(x::Vector{Float64}, ν::Vector{Float64}, λ::Vector{Float64}, A::Matrix{Float64}, B::Matrix{Float64}, dx::Vector{Float64}, diffmodel::DifferentiableModel, optimizer; modifications, use_analytic, scale_output)
```
The more types and/or arguments are used, the more difficult it becomes to see what the function signature is. JuliaFormatter.jl breaks docstrings into multiple lines if they are too long. This PR mimics this behavior, so that the docstring for `differentiate!` becomes:
```julia
  differentiate!(
    x::Vector{Float64},
    ν::Vector{Float64},
    λ::Vector{Float64},
    A::Matrix{Float64},
    B::Matrix{Float64},
    dx::Vector{Float64},
    diffmodel::DifferentiableModel,
    optimizer;
    modifications,
    use_analytic,
    scale_output
  )
```
Basically, a line width flag is used to decide when to break up a method signature, and if it is triggered, then new lines and space delimiters are used to format the docstring. We (@exaexa and I) have made this small patch and updated the tests. Let us know what you think!  