### PR TITLE
Fix extraction of argnames for generated functions (cherry-picked)

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -460,7 +460,7 @@ function arguments(m::Method)
         end
     end
     if !isnothing(argnames)
-        local args = map(argnames) do arg
+        local args = map(argnames[1:nargs(m)]) do arg
             arg === Symbol("#unused#") ? "_" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -449,9 +449,18 @@ args = arguments(first(methods(f)))
 ```
 """
 function arguments(m::Method)
-    local template = get_method_source(m)
-    if isdefined(template, :slotnames)
-        local args = map(template.slotnames[1:nargs(m)]) do arg
+    local argnames = nothing
+    if isdefined(m, :generator)
+        # Generated function.
+        argnames = m.generator.argnames
+    else
+        local template = get_method_source(m)
+        if isdefined(template, :slotnames)
+            argnames = template.slotnames
+        end
+    end
+    if !isnothing(argnames)
+        local args = map(argnames) do arg
             arg === Symbol("#unused#") ? "_" : arg
         end
         return filter(arg -> arg !== Symbol("#self#"), args)

--- a/test/TestModule/M.jl
+++ b/test/TestModule/M.jl
@@ -15,6 +15,9 @@ h_2(x::A{Int}) = x
 h_3(x::A{T}) where {T} = x
 h_4(x, ::Int, z) = x
 
+@generated g_1(x) = x
+@generated g_2(x::Integer) = x
+
 i_1(x; y = x) = x * y
 i_2(x::Int; y = x) = x * y
 i_3(x::T; y = x) where {T} = x * y

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -167,6 +167,17 @@ end
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
+                :binding => Docs.Binding(M, :g_1),
+                :typesig => Tuple{Any},
+                :module => M,
+            )
+            DSE.format(SIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("\ng_1(x)\n", str)
+            @test occursin("\n```\n", str)
+
+            doc.data = Dict(
                 :binding => Docs.Binding(M, :h_4),
                 :typesig => Union{Tuple{Any, Int, Any}},
                 :module => M,
@@ -196,6 +207,16 @@ end
             end
             @test occursin("\n```\n", str)
 
+            doc.data = Dict(
+                :binding => Docs.Binding(M, :g_2),
+                :typesig => Tuple{Integer},
+                :module => M,
+            )
+            DSE.format(TYPEDSIGNATURES, buf, doc)
+            str = String(take!(buf))
+            @test occursin("\n```julia\n", str)
+            @test occursin("\ng_2(x::Integer)", str)
+            @test occursin("\n```\n", str)
 
             doc.data = Dict(
                 :binding => Docs.Binding(M, :h),


### PR DESCRIPTION
Supersedes #127 from which I've `cherry-pick`ed your commits @serenity4 to maintain your authorship. Includes several test cases for the fix as well.