### PR TITLE
Support capturing `Expr` for use in abbreviations.

### DIFF
--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -82,6 +82,7 @@ import LibGit2
 export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS
 export SIGNATURES, TYPEDSIGNATURES, TYPEDEF, DOCSTRING, FUNCTIONNAME
 export README, LICENSE
+export interpolation
 
 # Includes.
 

--- a/src/templates.jl
+++ b/src/templates.jl
@@ -97,6 +97,7 @@ end
 # On v0.6 and below it seems it was assumed to be (docstr::String, expr::Expr), but on v0.7
 # it is (source::LineNumberNode, mod::Module, docstr::String, expr::Expr)
 function template_hook(source::LineNumberNode, mod::Module, docstr, expr::Expr)
+    docstr = _capture_expression(docstr, expr)
     # During macro expansion we only need to wrap docstrings in special
     # abbreviations that later print out what was before and after the
     # docstring in it's specific template. This is only done when the module

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -1,0 +1,21 @@
+module InterpolationTestModule
+
+struct TestType
+    value::Int
+end
+
+import DocStringExtensions
+
+DocStringExtensions.interpolation(obj::TestType, ex::Expr) = ex.args[obj.value]
+
+"""
+$(TestType(1))
+"""
+f(x) = x + 1
+
+"""
+$(TestType(2))
+"""
+g(x) = x + 2
+
+end

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -7,7 +7,7 @@ end
 import DocStringExtensions
 
 # For TestType(1), it interpolates the function signature, and for
-# TestType(1) it interpolates the function body.
+# TestType(2) it interpolates the function body.
 DocStringExtensions.interpolation(obj::TestType, ex::Expr) = ex.args[obj.value]
 
 """

--- a/test/interpolation.jl
+++ b/test/interpolation.jl
@@ -6,6 +6,8 @@ end
 
 import DocStringExtensions
 
+# For TestType(1), it interpolates the function signature, and for
+# TestType(1) it interpolates the function body.
 DocStringExtensions.interpolation(obj::TestType, ex::Expr) = ex.args[obj.value]
 
 """

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1,6 +1,7 @@
 const DSE = DocStringExtensions
 
 include("templates.jl")
+include("interpolation.jl")
 include("TestModule/M.jl")
 
 # initialize a test repo in test/TestModule which is needed for some tests
@@ -514,6 +515,12 @@ end
             @test occursin("(TYPES)", fmt(:(TemplateTests.OtherModule.ISSUE_115)))
             @test occursin("(MACROS)", fmt(:(TemplateTests.OtherModule.@m)))
             @test fmt(:(TemplateTests.OtherModule.f)) == "method `f`\n"
+        end
+    end
+    @testset "Interpolation" begin
+        let fmt = expr -> Markdown.plain(eval(:(@doc $expr)))
+            @test occursin("f(x)", fmt(:(InterpolationTestModule.f)))
+            @test occursin("x + 2", fmt(:(InterpolationTestModule.g)))
         end
     end
     @testset "utilities" begin


### PR DESCRIPTION
Should help handle #54, and possibly make other things easier to handle, such as #19 and other places where digging into the lowered code is a pain while dealing with the raw `Expr` would be more useful.

This intercepts documented expressions during macro expansion of `Core.@doc` and makes the documented `Expr` available for capturing and usage in abbreviation objects.