### PR TITLE
Condense $FIELDS template

### DIFF
--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -100,11 +100,9 @@ function format(abbrv::TypeFields, buf, doc)
     if !isempty(fields)
         println(buf)
         for field in fields
-            if abbrv.types
-                println(buf, "  - `", field, "::", fieldtype(object, field), "`")
-            else
-                println(buf, "  - `", field, "`")
-            end
+            print(buf, "  - `", field)
+            abbrv.types && print(buf, "::", fieldtype(object, field))
+            println(buf, "`")
             # Print the field docs if they exist and aren't a `doc"..."` docstring.
             if haskey(docs, field) && isa(docs[field], AbstractString)
                 println(buf)

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -96,8 +96,6 @@ function format(abbrv::TypeFields, buf, doc)
     local docs = get(doc.data, :fields, Dict())
     local binding = doc.data[:binding]
     local object = Docs.resolve(binding)
-    # On 0.7 fieldnames() on an abstract type throws an error. We then explicitly return
-    # an empty vector to be consistent with the behaviour on v0.6.
     local fields = isabstracttype(object) ? Symbol[] : fieldnames(object)
     if !isempty(fields)
         println(buf)

--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -81,13 +81,9 @@ type `Vector{Any}`.
 
   - `x::String`
 
-  - `y::Int`
+  - `y::Int`: Unlike the `x` field this field has been documented.
 
-    Unlike the `x` field this field has been documented.
-
-  - `z::Array{Any, 1}`
-
-    Another documented field.
+  - `z::Array{Any, 1}`: Another documented field.
 ```
 """
 const TYPEDFIELDS = TypeFields(true)
@@ -105,9 +101,11 @@ function format(abbrv::TypeFields, buf, doc)
             println(buf, "`")
             # Print the field docs if they exist and aren't a `doc"..."` docstring.
             if haskey(docs, field) && isa(docs[field], AbstractString)
-                println(buf)
+                print(buf, ": ")
+                indented = true
                 for line in split(docs[field], "\n")
-                    println(buf, isempty(line) ? "" : "    ", rstrip(line))
+                    println(buf, indented || isempty(line) ? "" : "    ", rstrip(line))
+                    indented = false
                 end
             end
             println(buf)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -201,7 +201,7 @@ end
             f = str -> replace(str, " " => "")
             str = f(str)
 
-            if VERSION == v"1.0" && Sys.iswindows()
+            if VERSION < v"1.1" && Sys.iswindows()
                 # on Windows, Julia 1.0 sorts Array{T,n} within Union in reverse order
                 @test_broken occursin(f("h_1(\nx::Union{Array{T,3}, Array{T,4}} where T\n) -> Union{Array{T,3}, Array{T,4}} where T"), str)
             else

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -200,8 +200,10 @@ end
             @test occursin("\n```julia\n", str)
             f = str -> replace(str, " " => "")
             str = f(str)
-            if Sys.iswindows()
-                @test occursin(f("h_1(\nx::Union{Array{T,4}, Array{T,3}} where T\n) -> Union{Array{T,4}, Array{T,3}} where T"), str)
+
+            if VERSION == v"1.0" && Sys.iswindows()
+                # on Windows, Julia 1.0 sorts Array{T,n} within Union in reverse order
+                @test_broken occursin(f("h_1(\nx::Union{Array{T,3}, Array{T,4}} where T\n) -> Union{Array{T,3}, Array{T,4}} where T"), str)
             else
                 @test occursin(f("h_1(\nx::Union{Array{T,3}, Array{T,4}} where T\n) -> Union{Array{T,3}, Array{T,4}} where T"), str)
             end


### PR DESCRIPTION
For `$FIELDS`/`$TYPEDFIELDS` templates, put the field description on the same line as the field name.

Example:
  - `x::String`
  - `y::Int`: Unlike the `x` field this field has been documented.
  - `z::Array{Any, 1}`: Another documented field.

Fixes #63