### PR TITLE
fix kw handling and filter out a new internal symbol from arguments 

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -419,7 +419,7 @@ function keywords(func, m::Method)
     # table is a MethodTable object. For some reason, the :kwsorter field is not always
     # defined. An undefined kwsorter seems to imply that there are no methods in the
     # MethodTable with keyword arguments.
-    if  !hasfield(Core.MethodTable, :kwsorter) || isdefined(table, :kwsorter)
+    if  !(fieldindex(Core.MethodTable, :kwsorter, false) > 0) || isdefined(table, :kwsorter)
         # Fetching method keywords stolen from base/replutil.jl:572-576 (commit 3b45cdc9aab0):
         kwargs = VERSION < v"1.4.0-DEV.215" ? Base.kwarg_decl(m, typeof(table.kwsorter)) : Base.kwarg_decl(m)
         if isa(kwargs, Vector) && length(kwargs) > 0

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -419,7 +419,7 @@ function keywords(func, m::Method)
     # table is a MethodTable object. For some reason, the :kwsorter field is not always
     # defined. An undefined kwsorter seems to imply that there are no methods in the
     # MethodTable with keyword arguments.
-    if  !(fieldindex(Core.MethodTable, :kwsorter, false) > 0) || isdefined(table, :kwsorter)
+    if  !(Base.fieldindex(Core.MethodTable, :kwsorter, false) > 0) || isdefined(table, :kwsorter)
         # Fetching method keywords stolen from base/replutil.jl:572-576 (commit 3b45cdc9aab0):
         kwargs = VERSION < v"1.4.0-DEV.215" ? Base.kwarg_decl(m, typeof(table.kwsorter)) : Base.kwarg_decl(m)
         if isa(kwargs, Vector) && length(kwargs) > 0

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -419,7 +419,7 @@ function keywords(func, m::Method)
     # table is a MethodTable object. For some reason, the :kwsorter field is not always
     # defined. An undefined kwsorter seems to imply that there are no methods in the
     # MethodTable with keyword arguments.
-    if isdefined(table, :kwsorter)
+    if  !hasfield(Core.MethodTable, :kwsorter) || isdefined(table, :kwsorter)
         # Fetching method keywords stolen from base/replutil.jl:572-576 (commit 3b45cdc9aab0):
         kwargs = VERSION < v"1.4.0-DEV.215" ? Base.kwarg_decl(m, typeof(table.kwsorter)) : Base.kwarg_decl(m)
         if isa(kwargs, Vector) && length(kwargs) > 0
@@ -463,7 +463,7 @@ function arguments(m::Method)
         local args = map(argnames[1:nargs(m)]) do arg
             arg === Symbol("#unused#") ? "_" : arg
         end
-        return filter(arg -> arg !== Symbol("#self#"), args)
+        return filter(arg -> arg !== Symbol("#self#") && arg !== Symbol("#ctor-self#"), args)
     end
     return Symbol[]
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -42,7 +42,7 @@ end
         @test isdefined(methods(M.j_1), :mt)
         local mt = methods(M.j_1).mt
         @test isa(mt, Core.MethodTable)
-        if hasfield(Core.MethodTable, :kwsorter)
+        if fieldindex(Core.MethodTable, :kwsorter, false) > 0
             @test isdefined(mt, :kwsorter)
         end
         # .kwsorter is not always defined -- namely, it seems when none of the methods

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -42,7 +42,7 @@ end
         @test isdefined(methods(M.j_1), :mt)
         local mt = methods(M.j_1).mt
         @test isa(mt, Core.MethodTable)
-        if fieldindex(Core.MethodTable, :kwsorter, false) > 0
+        if Base.fieldindex(Core.MethodTable, :kwsorter, false) > 0
             @test isdefined(mt, :kwsorter)
         end
         # .kwsorter is not always defined -- namely, it seems when none of the methods

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -42,7 +42,9 @@ end
         @test isdefined(methods(M.j_1), :mt)
         local mt = methods(M.j_1).mt
         @test isa(mt, Core.MethodTable)
-        @test isdefined(mt, :kwsorter)
+        if hasfield(Core.MethodTable, :kwsorter)
+            @test isdefined(mt, :kwsorter)
+        end
         # .kwsorter is not always defined -- namely, it seems when none of the methods
         # have keyword arguments:
         @test isdefined(methods(M.f).mt, :kwsorter) === false


### PR DESCRIPTION
The `kwsorter` field has been removed from the method table and there seems to be a new `#ctor-self#` argument that should be filtered out. Makes tests pass on master