### PR TITLE
Fix ordering of arguments on newer Windows versions

### DIFF
--- a/src/abbreviations.jl
+++ b/src/abbreviations.jl
@@ -394,7 +394,7 @@ function format(::TypedMethodSignatures, buf, doc)
                 end
             end
 
-            if Sys.iswindows()
+            @static if Sys.iswindows() && VERSION < v"1.8"
                 t = tuples[findlast(f, tuples)]
             else
                 t = tuples[findfirst(f, tuples)]

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -200,7 +200,7 @@ end
             @test occursin("\n```julia\n", str)
             f = str -> replace(str, " " => "")
             str = f(str)
-            if Sys.iswindows()
+            if Sys.iswindows() && VERSION < v"1.8"
                 @test occursin(f("h_1(\nx::Union{Array{T,4}, Array{T,3}} where T\n) -> Union{Array{T,4}, Array{T,3}} where T"), str)
             else
                 @test occursin(f("h_1(\nx::Union{Array{T,3}, Array{T,4}} where T\n) -> Union{Array{T,3}, Array{T,4}} where T"), str)


### PR DESCRIPTION
Older Windows versions of Julia used to have reversed ordering of arguments in the expressions that were processed, this has clearly been fixed in 1.8 and above, so make those conditions version dependant.