### PR TITLE
fix broadcast on `Base.rewrap_unionall` in `alltypesigs`

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -111,7 +111,8 @@ function alltypesigs(sig)::Vector{Any}
     elseif isa(sig, Union)
         uniontypes(sig)
     elseif isa(sig, UnionAll)
-        Base.rewrap_unionall.(uniontypes(Base.unwrap_unionall(sig)), sig)
+        Any[Base.rewrap_unionall(usig, sig) for
+            usig in uniontypes(Base.unwrap_unionall(sig))]
     else
         Any[sig]
     end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -619,11 +619,7 @@ end
             @test DSE.alltypesigs(Union{}) == Any[]
             @test DSE.alltypesigs(Union{Tuple{}}) == Any[Tuple{}]
             @test DSE.alltypesigs(Tuple{}) == Any[Tuple{}]
-
-            # TODO: Clean me up
-            T = Type{T} where {T}
-            @test DSE.alltypesigs(T) ==
-                Base.rewrap_unionall.(DSE.uniontypes(Base.unwrap_unionall(T)), T)
+            @test DSE.alltypesigs(Tuple{G} where G) == Any[Tuple{G} where G]
         end
         @testset "groupby" begin
             let groups = DSE.groupby(Int, Vector{Int}, collect(1:10)) do each


### PR DESCRIPTION
For me this fixes #102

Problematic use-case is roughly as follows:
```
julia> sig = (Tuple{G} where G)
Tuple{G} where G

julia> Base.rewrap_unionall.(DocStringExtensions.uniontypes(Base.unwrap_unionall(sig)), sig)
1-element Vector{DataType}:
 Tuple{G}

julia> Base.rewrap_unionall.(DocStringExtensions.uniontypes(Base.unwrap_unionall(sig)), Ref(sig))
1-element Vector{UnionAll}:
 Tuple{G} where G
```

I chose to avoid the `Ref(...)`-style broadcast-prevention; materializing a vector right away reads much better here.