### PR TITLE
Move the direct dependency on libgit2 to an extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.9'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,21 @@
 name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+version = "1.0.0"
 
-[deps]
+[weakdeps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
+[extensions]
+DocStringExtensionsLibGit2Ext = "LibGit2"
+
 [compat]
-julia = "1"
+julia = "1.9"
 
 [extras]
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Markdown", "Pkg", "Test"]
+test = ["LibGit2", "Markdown", "Pkg", "Test"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ pkg> add DocStringExtensions
 - [**STABLE**][docs-stable-url] &mdash; **most recently tagged version of the documentation.**
 - [**LATEST**][docs-latest-url] &mdash; *in-development version of the documentation.*
 
+## Updating to DocStringExtensions v1.0
+
+DocStringExtensions v1.0 is a breaking update. Only one breaking change is included, which is that
+the `url` functionality is now locked behind a package extension. This is because this functionality
+requires LibGit2, and thus requires any packages which wishes to use this function to have a direct
+runtime dependency which ships and loads a Git installation. This is a potentially large burden as
+DocStringExtensions.jl is a very core library to the Julia ecosystem, and thus it no longer requires
+that all dependencies load Git. If this functionality is required for your package and you wish to
+opt into the consequences of this dependency, simply add a direct dependency on LibGit2 and do
+`using LibGit2` to recover the functionality.
+
 ## Project Status
 
 The package is tested and developed against Julia `1.0`, as well as the latest `stable` and `nightly` versions on Linux, OS X, and Windows,

--- a/ext/DocStringExtensionsLibGit2Ext.jl
+++ b/ext/DocStringExtensionsLibGit2Ext.jl
@@ -1,0 +1,46 @@
+module DocStringExtensionsLibGit2Ext
+
+import DocStringExtensions
+import LibGit2
+
+function DocStringExtensions.url(mod::Module, file::AbstractString, line::Integer)
+    file = Sys.iswindows() ? replace(file, '\\' => '/') : file
+    if Base.inbase(mod) && !isabspath(file)
+        local base = "https://github.com/JuliaLang/julia/tree"
+        if isempty(Base.GIT_VERSION_INFO.commit)
+            return "$base/v$VERSION/base/$file#L$line"
+        else
+            local commit = Base.GIT_VERSION_INFO.commit
+            return "$base/$commit/base/$file#L$line"
+        end
+    else
+        if isfile(file)
+            local d = dirname(file)
+            try # might not be in a git repo
+                LibGit2.with(LibGit2.GitRepoExt(d)) do repo
+                    LibGit2.with(LibGit2.GitConfig(repo)) do cfg
+                        local u = LibGit2.get(cfg, "remote.origin.url", "")
+                        local m = match(LibGit2.GITHUB_REGEX, u)
+                        u = m === nothing ? get(ENV, "TRAVIS_REPO_SLUG", "") : m.captures[1]
+                        local commit = string(LibGit2.head_oid(repo))
+                        local root = LibGit2.path(repo)
+                        if startswith(file, root) || startswith(realpath(file), root)
+                            local base = "https://github.com/$u/tree"
+                            local filename = file[(length(root) + 1):end]
+                            return "$base/$commit/$filename#L$line"
+                        else
+                            return ""
+                        end
+                    end
+                end
+            catch err
+                isa(err, LibGit2.GitError) || rethrow()
+                return ""
+            end
+        else
+            return ""
+        end
+    end
+end
+
+end

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -73,10 +73,6 @@ $(IMPORTS)
 """
 module DocStringExtensions
 
-# Imports.
-
-import LibGit2
-
 # Exports.
 
 export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -524,44 +524,8 @@ on TravisCI as well.
 """
 url(m::Method) = url(m.module, string(m.file), m.line)
 
-function url(mod::Module, file::AbstractString, line::Integer)
-    file = Sys.iswindows() ? replace(file, '\\' => '/') : file
-    if Base.inbase(mod) && !isabspath(file)
-        local base = "https://github.com/JuliaLang/julia/tree"
-        if isempty(Base.GIT_VERSION_INFO.commit)
-            return "$base/v$VERSION/base/$file#L$line"
-        else
-            local commit = Base.GIT_VERSION_INFO.commit
-            return "$base/$commit/base/$file#L$line"
-        end
-    else
-        if isfile(file)
-            local d = dirname(file)
-            try # might not be in a git repo
-                LibGit2.with(LibGit2.GitRepoExt(d)) do repo
-                    LibGit2.with(LibGit2.GitConfig(repo)) do cfg
-                        local u = LibGit2.get(cfg, "remote.origin.url", "")
-                        local m = match(LibGit2.GITHUB_REGEX, u)
-                        u = m === nothing ? get(ENV, "TRAVIS_REPO_SLUG", "") : m.captures[1]
-                        local commit = string(LibGit2.head_oid(repo))
-                        local root = LibGit2.path(repo)
-                        if startswith(file, root) || startswith(realpath(file), root)
-                            local base = "https://github.com/$u/tree"
-                            local filename = file[(length(root) + 1):end]
-                            return "$base/$commit/$filename#L$line"
-                        else
-                            return ""
-                        end
-                    end
-                end
-            catch err
-                isa(err, LibGit2.GitError) || rethrow()
-                return ""
-            end
-        else
-            return ""
-        end
-    end
+function url(mod, file, line)
+    error("This method requires loading the LibGit2 extension as it requires a Git provider for URL handling. Do `using LibGit2` and add LibGit2 as a dependency in order to use this functionality.")
 end
 
 # This is compat to make sure that we have ismutabletype available pre-1.7.


### PR DESCRIPTION
This is a breaking change, and thus updated to v1.0 with a note in the README on updating. 