### PR TITLE
Remove LibGit2 dep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,16 +2,14 @@ name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.3"
 
-[deps]
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
 [compat]
 julia = "1"
 
 [extras]
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Markdown", "Pkg", "Test"]
+test = ["LibGit2", "Markdown", "Pkg", "Test"]

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -75,7 +75,6 @@ module DocStringExtensions
 
 # Imports.
 
-import LibGit2
 
 # Exports.
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -517,11 +517,17 @@ end
 """
 $(:SIGNATURES)
 
-Get the URL (file and line number) where a method `m` is defined.
+Get the URL (file and line number) where a method `m` is defined. May return an empty string
+if the URL can not be determined.
 
-Note that this is `Base.url`.
+Requires the `LibGit2` to be present in the environment.
 """
-url(m::Method) = Base.url(m)
+function url(m::Method)
+    # Base.url() something produces file:// URLs, but we want these to be sharable web URLs.
+    # So we just say we couldn't determine the URL if we get one of those.
+    url = Base.url(m)
+    return startswith(url, "file://") ? "" : url
+end
 
 # This is compat to make sure that we have ismutabletype available pre-1.7.
 # Implementation borrowed from JuliaLang/julia (MIT license).

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -459,7 +459,7 @@ function keywords(func, m::Method)
     if  !(Base.fieldindex(Core.MethodTable, :kwsorter, false) > 0) || isdefined(table, :kwsorter)
         # Fetching method keywords stolen from base/replutil.jl:572-576 (commit 3b45cdc9aab0):
         kwargs = VERSION < v"1.4.0-DEV.215" ? Base.kwarg_decl(m, typeof(table.kwsorter)) : Base.kwarg_decl(m)
-        if isa(kwargs, Vector) && length(kwargs) > 0 && kwargs != [:...] # in julia 1.10 sometimes kwargs is `[:...]`, ignore that
+        if isa(kwargs, Vector) && length(kwargs) > 0
             filter!(arg -> !occursin("#", string(arg)), kwargs)
             # Keywords *may* not be sorted correctly. We move the vararg one to the end.
             index = findfirst(arg -> endswith(string(arg), "..."), kwargs)


### PR DESCRIPTION
Alternative to #165

This only supports GitHub URLs right now. Ultimately it would be nice if this could somehow hook into https://documenter.juliadocs.org/stable/lib/remote-links/#remotes-for-files 