### PR TITLE
Fix tests on Julia 1.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - master
     tags:
       - '*'
+  schedule:
+    - cron: '0 0 * * 1' # runs 00:00 UTC on every Monday
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -151,8 +151,15 @@ end
             DSE.format(SIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\ng()\n", str)
-            @test occursin("\ng(x)\n", str)
+            # On 1.10+, automatically generated methods have keywords in the metadata,
+            # hence the display difference between Julia versions.
+            if VERSION >= v"1.10"
+                @test occursin("\ng(; ...)\n", str)
+                @test occursin("\ng(x; ...)\n", str)
+            else
+                @test occursin("\ng()\n", str)
+                @test occursin("\ng()\n", str)
+            end
             @test occursin("\n```\n", str)
 
             doc.data = Dict(
@@ -163,9 +170,17 @@ end
             DSE.format(SIGNATURES, buf, doc)
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
-            @test occursin("\ng()\n", str)
-            @test occursin("\ng(x)\n", str)
-            @test occursin("\ng(x, y)\n", str)
+            # On 1.10+, automatically generated methods have keywords in the metadata,
+            # hence the display difference between Julia versions.
+            if VERSION >= v"1.10"
+                @test occursin("\ng(; ...)\n", str)
+                @test occursin("\ng(x; ...)\n", str)
+                @test occursin("\ng(x, y; ...)\n", str)
+            else
+                @test occursin("\ng()\n", str)
+                @test occursin("\ng(x)\n", str)
+                @test occursin("\ng(x, y)\n", str)
+            end
             @test occursin("\ng(x, y, z; kwargs...)\n", str)
             @test occursin("\n```\n", str)
 
@@ -245,9 +260,21 @@ end
             str = String(take!(buf))
             @test occursin("\n```julia\n", str)
             if typeof(1) === Int64
-                @test occursin("\nh(x::Int64) -> Int64\n", str)
+                # On 1.10+, automatically generated methods have keywords in the metadata,
+                # hence the display difference between Julia versions.
+                if VERSION >= v"1.10"
+                    @test occursin("\nh(x::Int64; ...) -> Int64\n", str)
+                else
+                    @test occursin("\nh(x::Int64) -> Int64\n", str)
+                end
             else
-                @test occursin("\nh(x::Int32) -> Int32\n", str)
+                # On 1.10+, automatically generated methods have keywords in the metadata,
+                # hence the display difference between Julia versions.
+                if VERSION >= v"1.10"
+                    @test occursin("\nh(x::Int32; ...) -> Int32\n", str)
+                else
+                    @test occursin("\nh(x::Int32) -> Int32\n", str)
+                end
             end
             @test occursin("\n```\n", str)
 


### PR DESCRIPTION
Alternative to #167. It looks like there has been a bugfix in 1.10, and the auto-generated methods when you have positional arguments with default values:

https://github.com/JuliaDocs/DocStringExtensions.jl/blob/ec66ad4a472241c7a7ae0686247fe578c5e50210/test/TestModule/M.jl#L7

On 1.9:

```
julia> methods(M.g)
# 4 methods for generic function "g" from Main.M:
 [1] g()
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [2] g(x)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [3] g(x, y)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [4] g(x, y, z; kwargs...)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
```

vs on 1.10:

```
julia> methods(M.g)
# 4 methods for generic function "g" from Main.M:
 [1] g(; ...)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [2] g(x, y, z; kwargs...)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [3] g(x, y; ...)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
 [4] g(x; ...)
     @ ~/juliadocs/clones/DocStringExtensions.jl/test/TestModule/M.jl:7
```

So I would argue that the new printing is more correct actually, and so we should instead make the tests version-conditional.

It wasn't obvious to me if there's any way to support the new printing on older Julia versions -- it looks like the information about the kwargs is just missing from the method metadata. It would be good to know which PR in Julia changed this though.

Also makes the CI to run weekly on a schedule, so that we'd maybe catch nightly regressions earlier.