### PR TITLE
Add support for default values to `TYPEDSIGNATURES`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.9.3"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [compat]
+REPL = "1"
 julia = "1"
 
 [extras]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [targets]
-test = ["Markdown", "Pkg", "Test"]
+test = ["Markdown", "Pkg", "Test", "REPL"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,16 @@ version = "0.9.3"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
 [compat]
+CodeTracking = "1.3.6"
 REPL = "1"
 julia = "1"
 
 [extras]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Markdown", "Pkg", "Test", "REPL"]
+test = ["Markdown", "Pkg", "Test", "REPL", "CodeTracking"]

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -86,6 +86,7 @@ export interpolation
 
 # Includes.
 
+include("parsing.jl")
 include("utilities.jl")
 include("abbreviations.jl")
 include("templates.jl")

--- a/src/parsing.jl
+++ b/src/parsing.jl
@@ -1,0 +1,122 @@
+Base.@kwdef struct ASTArg
+    name::Union{Symbol, Nothing} = nothing
+    type = nothing
+    default = nothing
+    variadic::Bool = false
+end
+
+# Parse an argument with a type annotation.
+# Example input: `x::Int`
+function parse_arg_with_type(arg_expr::Expr)
+    if arg_expr.head != :(::)
+        throw(ArgumentError("Argument is not a :(::) expr"))
+    end
+
+    n_expr_args = length(arg_expr.args)
+    return if n_expr_args == 1
+        # '::Int'
+        ASTArg(; type=arg_expr.args[1])
+    elseif n_expr_args == 2
+        # 'x::Int'
+        ASTArg(; name=arg_expr.args[1], type=arg_expr.args[2])
+    end
+end
+
+# Parse an argument with a default value.
+# Example input: `x=5`
+function parse_arg_with_default(arg_expr::Expr)
+    if arg_expr.head != :kw
+        throw(ArgumentError("Argument is not a :kw expr"))
+    end
+
+    if arg_expr.args[1] isa Symbol
+        # This is an argument without a type annotation
+        ASTArg(; name=arg_expr.args[1], default=arg_expr.args[2])
+    else
+        # This is an argument with a type annotation
+        tmp = parse_arg_with_type(arg_expr.args[1])
+        ASTArg(; name=tmp.name, type=tmp.type, default=arg_expr.args[2])
+    end
+end
+
+# Parse a list of expressions, assuming the list is an argument list containing
+# positional/keyword arguments.
+# Example input: `(x, y::Int; z=5, kwargs...)`
+function parse_arglist!(exprs, args, kwargs, is_kwarg_list=false)
+    list = is_kwarg_list ? kwargs : args
+
+    for arg_expr in exprs
+        if arg_expr isa Symbol
+            # Plain argument name with no type or default value
+            push!(list, ASTArg(; name=arg_expr))
+        elseif arg_expr.head == :(::)
+            # With a type annotation
+            push!(list, parse_arg_with_type(arg_expr))
+        elseif arg_expr.head == :kw
+            # With a default value (and possibly a type annotation)
+            push!(list, parse_arg_with_default(arg_expr))
+        elseif arg_expr.head == :parameters
+            # Keyword arguments
+            parse_arglist!(arg_expr.args, args, kwargs, true)
+        elseif arg_expr.head === :...
+            # Variadic argument
+            if arg_expr.args[1] isa Symbol
+                # Without a type annotation
+                push!(list, ASTArg(; name=arg_expr.args[1], variadic=true))
+            elseif arg_expr.args[1].head === :(::)
+                # With a type annotation
+                arg_expr = arg_expr.args[1]
+                push!(list, ASTArg(; name=arg_expr.args[1], type=arg_expr.args[2], variadic=true))
+            else
+                Meta.dump(arg_expr)
+                error("Couldn't parse variadic Expr in arg list (printed above)")
+            end
+        else
+            Meta.dump(arg_expr)
+            error("Couldn't parse Expr in arg list (printed above)")
+        end
+    end
+end
+
+# Find a :call expression within an Expr. This will take care of ignoring other
+# tokens like `where` clauses.
+function find_call_expr(expr::Expr)
+    if expr.head === :macrocall && expr.args[1] === Symbol("@generated")
+        # If this is a generated function, find the first := expr to find
+        # the :call expr.
+        assignment_idx = findfirst(x -> x isa Expr && x.head === :(=), expr.args)
+
+        expr.args[assignment_idx].args[1]
+    elseif expr.head === :(=)
+        find_call_expr(expr.args[1])
+    elseif expr.head == :where
+        # Function with one or more `where` clauses
+        find_call_expr(expr.args[1])
+    elseif expr.head === :function
+        find_call_expr(expr.args[1])
+    elseif expr.head === :call
+        expr
+    else
+        Meta.dump(expr)
+        error("Can't parse current expr (printed above)")
+    end
+end
+
+# Parse an expression to find a :call expr, and return as much information as
+# possible about the arguments.
+# Example input: `foo(x) = x^2`
+function parse_call(expr::Expr)
+    Base.remove_linenums!(expr)
+    expr = find_call_expr(expr)
+
+    if expr.head != :call
+        throw(ArgumentError("Argument is not a :call, cannot parse it."))
+    end
+
+    args = ASTArg[]
+    kwargs = ASTArg[]
+    # Skip the first argument because that's just the function name
+    parse_arglist!(expr.args[2:end], args, kwargs)
+
+    return (; args, kwargs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using DocStringExtensions
+import DocStringExtensions: TypedMethodSignatures
+
 using Test
 import Markdown
 import LibGit2

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -1,3 +1,4 @@
+using REPL # Hack to get around: https://github.com/JuliaLang/julia/issues/52986
 const DSE = DocStringExtensions
 
 include("templates.jl")


### PR DESCRIPTION
This is done by making `TypedMethodSignatures` interpolatable and giving it the Expr of the thing the docstring is bound to. From the AST we can parse each arguments name, type annotation, default value, and whether or not it's variadic. Currently only the default value is used in `TYPEDSIGNATURES`, though in the future it might be an idea to use the type information as well.

I think this could do with some more tests (parsing is hard :cry:), but it's pretty close to being complete. Fixes #107, fixes #19. Would make #97 possible if we're ok with getting the types from the AST.