### PR TITLE
Remove `LibGit2` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1.0'

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,8 @@ julia = "1"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LibGit2", "Markdown", "Pkg", "Test"]
+test = ["LibGit2", "Markdown", "Pkg", "REPL", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,16 +2,14 @@ name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.9.3"
 
-[deps]
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
 [compat]
 julia = "1"
 
 [extras]
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Markdown", "Pkg", "Test"]
+test = ["LibGit2", "Markdown", "Pkg", "Test"]

--- a/src/DocStringExtensions.jl
+++ b/src/DocStringExtensions.jl
@@ -73,10 +73,6 @@ $(IMPORTS)
 """
 module DocStringExtensions
 
-# Imports.
-
-import LibGit2
-
 # Exports.
 
 export @template, FIELDS, TYPEDFIELDS, EXPORTS, METHODLIST, IMPORTS

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -530,10 +530,10 @@ function url(m::Method)
         root = get(ENV, "TRAVIS_BUILD_DIR", nothing)
         root === nothing && return ""
 
-        file = string(m.file)
-        if startswith(file, root) || startswith(realpath(file), root)
+        file = realpath(string(m.file))
+        if startswith(file, root)
+            filename = join(split(relpath(file, root), @static Sys.iswindows() ? '\\' : '/'), '/')
             base = "https://github.com/$repo/tree"
-            filename = join(splitpath(lstrip(file[(length(root)+1):end], '/')), '/')
             return "$base/$commit/$filename#L$(m.line)"
         else
             return ""

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -508,8 +508,6 @@ end
 #
 # Source URLs.
 #
-# Based on code from https://github.com/JuliaLang/julia/blob/master/base/methodshow.jl.
-#
 # Customised to handle URLs on travis since the directory is not a Git repo and we must
 # instead rely on `TRAVIS_REPO_SLUG` to get the remote repo.
 #
@@ -522,45 +520,25 @@ Get the URL (file and line number) where a method `m` is defined.
 Note that this is based on the implementation of `Base.url`, but handles URLs correctly
 on TravisCI as well.
 """
-url(m::Method) = url(m.module, string(m.file), m.line)
-
-function url(mod::Module, file::AbstractString, line::Integer)
-    file = Sys.iswindows() ? replace(file, '\\' => '/') : file
-    if Base.inbase(mod) && !isabspath(file)
-        local base = "https://github.com/JuliaLang/julia/tree"
-        if isempty(Base.GIT_VERSION_INFO.commit)
-            return "$base/v$VERSION/base/$file#L$line"
+function url(m::Method)
+    if haskey(ENV, "TRAVIS_REPO_SLUG")
+        repo = ENV["TRAVIS_REPO_SLUG"]
+        commit = get(ENV, "TRAVIS_COMMIT", nothing)
+        root = get(ENV, "TRAVIS_BUILD_DIR", nothing)
+        if any(isnothing, (commit, root))
+            return ""
         else
-            local commit = Base.GIT_VERSION_INFO.commit
-            return "$base/$commit/base/$file#L$line"
-        end
-    else
-        if isfile(file)
-            local d = dirname(file)
-            try # might not be in a git repo
-                LibGit2.with(LibGit2.GitRepoExt(d)) do repo
-                    LibGit2.with(LibGit2.GitConfig(repo)) do cfg
-                        local u = LibGit2.get(cfg, "remote.origin.url", "")
-                        local m = match(LibGit2.GITHUB_REGEX, u)
-                        u = m === nothing ? get(ENV, "TRAVIS_REPO_SLUG", "") : m.captures[1]
-                        local commit = string(LibGit2.head_oid(repo))
-                        local root = LibGit2.path(repo)
-                        if startswith(file, root) || startswith(realpath(file), root)
-                            local base = "https://github.com/$u/tree"
-                            local filename = file[(length(root) + 1):end]
-                            return "$base/$commit/$filename#L$line"
-                        else
-                            return ""
-                        end
-                    end
-                end
-            catch err
-                isa(err, LibGit2.GitError) || rethrow()
+            file = string(m.file)
+            if startswith(file, root) || startswith(realpath(file), root)
+                base = "https://github.com/$repo/tree"
+                filename = lstrip(file[(length(root)+1):end], '/')
+                return "$base/$commit/$filename#L$(m.line)"
+            else
                 return ""
             end
-        else
-            return ""
         end
+    else
+        return Base.url(m)
     end
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -533,7 +533,7 @@ function url(m::Method)
         file = string(m.file)
         if startswith(file, root) || startswith(realpath(file), root)
             base = "https://github.com/$repo/tree"
-            filename = lstrip(file[(length(root)+1):end], '/')
+            filename = join(splitpath(lstrip(file[(length(root)+1):end], '/')), '/')
             return "$base/$commit/$filename#L$(m.line)"
         else
             return ""

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -523,19 +523,20 @@ on TravisCI as well.
 function url(m::Method)
     if haskey(ENV, "TRAVIS_REPO_SLUG")
         repo = ENV["TRAVIS_REPO_SLUG"]
+
         commit = get(ENV, "TRAVIS_COMMIT", nothing)
+        commit === nothing && return ""
+
         root = get(ENV, "TRAVIS_BUILD_DIR", nothing)
-        if any(isnothing, (commit, root))
-            return ""
+        root === nothing && return ""
+
+        file = string(m.file)
+        if startswith(file, root) || startswith(realpath(file), root)
+            base = "https://github.com/$repo/tree"
+            filename = lstrip(file[(length(root)+1):end], '/')
+            return "$base/$commit/$filename#L$(m.line)"
         else
-            file = string(m.file)
-            if startswith(file, root) || startswith(realpath(file), root)
-                base = "https://github.com/$repo/tree"
-                filename = lstrip(file[(length(root)+1):end], '/')
-                return "$base/$commit/$filename#L$(m.line)"
-            else
-                return ""
-            end
+            return ""
         end
     else
         return Base.url(m)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,6 @@ using DocStringExtensions
 using Test
 import Markdown
 import LibGit2
+import REPL
 
 include("tests.jl")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -698,6 +698,13 @@ end
                 @test occursin("github.com/JuliaDocs/NonExistent", DSE.url(first(methods(M.f))))
                 @test occursin("github.com/JuliaDocs/NonExistent", DSE.url(first(methods(M.K))))
             end
+            withenv(
+                "TRAVIS_REPO_SLUG" => "JuliaDocs/NonExistent",
+                "TRAVIS_COMMIT" => "<commit>",
+                "TRAVIS_BUILD_DIR" => dirname(@__DIR__)
+            ) do
+                @test occursin("github.com/JuliaDocs/NonExistent/tree/<commit>/test/TestModule/M.jl", DSE.url(first(methods(M.f))))
+            end
         end
         @testset "comparemethods" begin
             let f = first(methods(M.f)),


### PR DESCRIPTION
This removes the `LibGit2` dependency, which was initially added back in https://github.com/JuliaDocs/DocStringExtensions.jl/pull/4 do deal with Travis not using an actual git repo as the build directory. We had to vendor `Base.url` which brought in the `LibGit2` dep. Instead change the logic in the `url` wrapper function to check whether Travis is the likely environment and generate an URL based solely on it's env vars, otherwise just use `Base.url` directly and whatever it's result is.

When `LibGit2` isn't actually loaded (https://github.com/JuliaLang/julia/blob/08c87b20993dc969f42b1a6eb50b931c66f311de/base/methodshow.jl#L393-L395) then of course `Base.url` won't return what's needed, and maybe that's fine since you can just ensure `LibGit2` is loaded in the process. This seems more straightforward than us internally falling back to a `git` that may or may not be available on the `PATH`.

---

I'm not sure how much use Travis sees these days... I've not touched it in years, but perhaps there's still users so I didn't want to completely remove the feature. (We can also just delete the feature if there's no users :)