### PR TITLE
Fixes for nightly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DocStringExtensions"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.4"
+version = "0.9.5"
 
 [compat]
 julia = "1"

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -457,7 +457,7 @@ function keywords(func, m::Method)
         # For some reason, the :kwsorter field is not always defined.
         # An undefined kwsorter seems to imply that there are no methods
         # in the MethodTable with keyword arguments.
-        if !isdefined(table, :kwsorter)
+        if Base.fieldindex(Core.MethodTable, :kwsorter, false) > 0 && !isdefined(table, :kwsorter)
             return Symbol[]
         end
         Base.kwarg_decl(m, typeof(table.kwsorter))

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -452,10 +452,10 @@ kws = keywords(f, first(methods(f)))
 ```
 """
 function keywords(func, m::Method)
-    table = methods(func).mt
-    # table is a MethodTable object. For some reason, the :kwsorter field is not always
-    # defined. An undefined kwsorter seems to imply that there are no methods in the
-    # MethodTable with keyword arguments.
+    table::Core.MethodTable = VERSION ≥ v"1.13.0-DEV.647" ? Core.GlobalMethods : methods(func).mt
+    # For some reason, the :kwsorter field is not always defined.
+    # An undefined kwsorter seems to imply that there are no methods
+    # in the MethodTable with keyword arguments.
     if  !(Base.fieldindex(Core.MethodTable, :kwsorter, false) > 0) || isdefined(table, :kwsorter)
         # Fetching method keywords stolen from base/replutil.jl:572-576 (commit 3b45cdc9aab0):
         kwargs = VERSION < v"1.4.0-DEV.215" ? Base.kwarg_decl(m, typeof(table.kwsorter)) : Base.kwarg_decl(m)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -452,7 +452,7 @@ kws = keywords(f, first(methods(f)))
 ```
 """
 function keywords(func, m::Method)
-    kwargs = @static if VERSION < v"1.4"
+    kwargs = @static if VERSION < v"1.4.0-DEV.215"
         table::Core.MethodTable = methods(func).mt
         # For some reason, the :kwsorter field is not always defined.
         # An undefined kwsorter seems to imply that there are no methods


### PR DESCRIPTION
Method table internals changed in https://github.com/JuliaLang/julia/commit/1735d8f03c9e4fedba652e4e562c049ac48c93fd, breaking our former reliance on `(::MethodList).mt`.

The associated error was originally observed [here](https://github.com/JuliaGPU/Vulkan.jl/actions/runs/15362623850/job/43231635465#step:7:329).